### PR TITLE
Fixed PCLRGAT -> CLRGAT_N problem

### DIFF
--- a/COMMON/COMMON_INTERNALS.vhdl
+++ b/COMMON/COMMON_INTERNALS.vhdl
@@ -11,8 +11,8 @@ entity COMMON_INTERNALS is
         PHI_0  : in std_logic;
 
         RC01X_N   : out std_logic;
-        P_PHI_0   : out std_logic;  -- Probaly means Phase-shifted PHI_0
-        P_PHI_1   : out std_logic;  -- Probaly means Phase-shifted PHI_1
+        P_PHI_0   : out std_logic; -- Probaly means Phase-shifted PHI_0
+        P_PHI_1   : out std_logic; -- Probaly means Phase-shifted PHI_1
         Q3_PRAS_N : out std_logic
     );
 end COMMON_INTERNALS;

--- a/IOU/IOU.vhdl
+++ b/IOU/IOU.vhdl
@@ -43,7 +43,7 @@ architecture RTL of IOU is
         port (
             PHI_0 : in std_logic;
 
-            POC_N  : out std_logic
+            POC_N : out std_logic
         );
     end component;
 
@@ -326,7 +326,7 @@ architecture RTL of IOU is
 
     signal RC01X_N, P_PHI_0, P_PHI_1, Q3_PRAS_N                                                   : std_logic;
     signal P_PHI_2, PHI_1, CTC14S                                                                 : std_logic;
-    signal FORCE_RESET_N_LOW, RESET_N, IN_RESET                                              : std_logic;
+    signal FORCE_RESET_N_LOW, RESET_N, IN_RESET                                                   : std_logic;
     signal HPE_N, V5, V4, V3, V2, V1, V0, VC, VB, VA, H5, H4, H3, H2, H1, PAKST, TC, TC14S, FLASH : std_logic;
     signal HIRESEN_N, C040_7_N, HBL, BL_N, VBL_N, V1_N_V5_N, V2_V2_N, SERR, KSTRB, AKD            : std_logic;
     signal EN80VID, FLG1, FLG2, PENIO_N, ALTSTKZP, INTC300_N, INTC300, S_80COL, PAYMAR            : std_logic;
@@ -346,7 +346,7 @@ architecture RTL of IOU is
     signal H0_INT, LGR_TXT_N_INT, ORA7_INT : std_logic;
 begin
     U_POWER_ON_DETECTION : POWER_ON_DETECTION port map(
-        PHI_0   => PHI_0,
+        PHI_0 => PHI_0,
         POC_N => POC_N
     );
 
@@ -375,7 +375,7 @@ begin
     U_IOU_RESET : IOU_RESET port map(
         PHI_1             => PHI_1,
         TC                => TC,
-        POC_N               => POC_N,
+        POC_N             => POC_N,
         FORCE_RESET_N_LOW => FORCE_RESET_N_LOW
     );
     IN_RESET    <= PIN_RESET_N;

--- a/IOU/IOU_INTERNALS.vhdl
+++ b/IOU/IOU_INTERNALS.vhdl
@@ -38,10 +38,10 @@ architecture RTL of IOU_INTERNALS is
     signal HBL_N       : std_logic;
     signal H2_N, H3_N  : std_logic;
     signal R9_6        : std_logic;
-    signal KSTRB_SHIFT : std_logic_vector(1 downto 0);  -- It's safe if we don't initialize KSTRB_SHIFT and AKD_SHIFT
-    signal AKD_SHIFT   : std_logic_vector(1 downto 0);  --   at power-on: P_PHI_2 will cycle several times during power-on
-                                                        --   and '0' will be shifted in these signals each time effectively
-                                                        --   initializing them to "00"
+    signal KSTRB_SHIFT : std_logic_vector(1 downto 0); -- It's safe if we don't initialize KSTRB_SHIFT and AKD_SHIFT
+    signal AKD_SHIFT   : std_logic_vector(1 downto 0); --   at power-on: P_PHI_2 will cycle several times during power-on
+                                                       --   and '0' will be shifted in these signals each time effectively
+                                                       --   initializing them to "00"
 
     signal HBL_INT, VBL_N_INT, SERR_INT, V1_N_V5_N_INT, V2_V2_N_INT : std_logic;
 begin

--- a/IOU/IOU_RESET.vhdl
+++ b/IOU/IOU_RESET.vhdl
@@ -25,7 +25,7 @@ architecture RTL of IOU_RESET is
 begin
     process (POC_N, TC, PHI_1)
     begin
-        if(POC_N = '0') then
+        if (POC_N = '0') then
             PWR_ON_FINISHED <= '0';
         elsif (TC = '1' and PHI_1 = '1') then
             PWR_ON_FINISHED <= '1';

--- a/IOU/IOU_TIMINGS.vhdl
+++ b/IOU/IOU_TIMINGS.vhdl
@@ -8,7 +8,7 @@ entity IOU_TIMINGS is
         PRAS_N  : in std_logic;
         TC14S   : in std_logic;
 
-        P_PHI_2 : out std_logic;  -- Probaly means Phase-shifted PHI_2
+        P_PHI_2 : out std_logic; -- Probaly means Phase-shifted PHI_2
         PHI_1   : out std_logic;
         CTC14S  : out std_logic
     );

--- a/IOU/POWER_ON_DETECTION.vhdl
+++ b/IOU/POWER_ON_DETECTION.vhdl
@@ -40,33 +40,32 @@ use ieee.numeric_std.all;
 -- On power-on, the signal POC_N should be held LOW for 2.4ms and then driven HIGH. It shoult then
 -- remain HIGH as long as the device has power.
 
--- FIXME: Move tests
 entity POWER_ON_DETECTION is
     port (
         PHI_0 : in std_logic;
 
-        POC_N  : out std_logic := '0'  -- Initialization only used by tests to
-                                       --    mock requirement that the device should
-                                       --    initialize all memory elements to '0'
+        POC_N : out std_logic := '0' -- Initialization only used by tests to
+                                     --    mock requirement that the device should
+                                     --    initialize all memory elements to '0'
     );
 end POWER_ON_DETECTION;
 
 architecture RTL of POWER_ON_DETECTION is
-	constant COUNT_2_4_MS : unsigned(11 downto 0) := x"991";  -- 2449 in hex
+    constant COUNT_2_4_MS : unsigned(11 downto 0) := x"991"; -- 2449 in hex
 
-    signal COUNT          : unsigned(11 downto 0) := (others => '0');  -- Initialization only used by tests to
-                                                                       --    mock requirement that the device should
-                                                                       --    initialize all memory elements to '0'
+    signal COUNT : unsigned(11 downto 0) := (others => '0'); -- Initialization only used by tests to
+                                                             --    mock requirement that the device should
+                                                             --    initialize all memory elements to '0'
 begin
     process (PHI_0)
     begin
         if (rising_edge(PHI_0)) then
-			if (COUNT < COUNT_2_4_MS) then
-				COUNT <= COUNT + 1;
-				POC_N <= '0';
-			else
+            if (COUNT < COUNT_2_4_MS) then
+                COUNT      <= COUNT + 1;
+                POC_N      <= '0';
+            else
                 POC_N <= '1';
-			end if;
+            end if;
         end if;
     end process;
 

--- a/IOU/VIDEO_GENERATOR.vhdl
+++ b/IOU/VIDEO_GENERATOR.vhdl
@@ -61,7 +61,7 @@ begin
     process (P_PHI_1, PCLRGAT)
     begin
         if (P_PHI_1 = '1') then
-            CLRGAT_N <= PCLRGAT;
+            CLRGAT_N <= not PCLRGAT;
         end if;
     end process;
 

--- a/IOU/VIDEO_GRAPHICS.vhdl
+++ b/IOU/VIDEO_GRAPHICS.vhdl
@@ -33,8 +33,8 @@ begin
     begin
         if (rising_edge(P_PHI_2)) then
             if (PGR_TXT_N_INT = '0') then
-                SEGA <= VA;
-                SEGB <= VB;
+                SEGA      <= VA;
+                SEGB      <= VB;
             else
                 SEGA <= H0;
                 SEGB <= HIRESEN_N;

--- a/IOU/VIDEO_SCANNER.vhdl
+++ b/IOU/VIDEO_SCANNER.vhdl
@@ -23,8 +23,8 @@ end VIDEO_SCANNER;
 -- tries to keep close to the emulator schematics, but this is an exception. The implementation below is
 -- more efficient and simpler than 6x LS161s chained with a ripple carry overflow.
 architecture RTL of VIDEO_SCANNER is
-    signal counters : unsigned(23 downto 0);  -- It's safe if we don't initialize counters: at power-up POC_N is LOW
-                                              --    and will initialize the signal.
+    signal counters : unsigned(23 downto 0); -- It's safe if we don't initialize counters: at power-up POC_N is LOW
+                                             --    and will initialize the signal.
 
     signal HPE_N_INT, VA_INT, TC_INT : std_logic;
 begin

--- a/MMU/MMU_SELMB.vhdl
+++ b/MMU/MMU_SELMB.vhdl
@@ -2,38 +2,38 @@ library IEEE;
 use IEEE.std_logic_1164.all;
 
 entity MMU_SELMB is
-	port (
-		A15, A14,
-		A13, A10    : in std_logic;
-		HIRES       : in std_logic;
-		PHI_0_7XX   : in std_logic;
-		EN80VID     : in std_logic;
-		PG2         : in std_logic;
-		FLG1        : in std_logic;
-		FLG2        : in std_logic;
-		R_W_N       : in std_logic;
-		ALTSTKZP    : in std_logic;
-		D_FXXX      : in std_logic;
-		PHI_0_1XX_N : in std_logic;
+    port (
+        A15, A14,
+        A13, A10    : in std_logic;
+        HIRES       : in std_logic;
+        PHI_0_7XX   : in std_logic;
+        EN80VID     : in std_logic;
+        PG2         : in std_logic;
+        FLG1        : in std_logic;
+        FLG2        : in std_logic;
+        R_W_N       : in std_logic;
+        ALTSTKZP    : in std_logic;
+        D_FXXX      : in std_logic;
+        PHI_0_1XX_N : in std_logic;
 
-		SELMB_N : out std_logic
-	);
+        SELMB_N : out std_logic
+    );
 end MMU_SELMB;
 
 architecture RTL of MMU_SELMB is
-	signal L2_11, K4_10, K7_6, K7_8, S3_3, S3_8, L3_4 : std_logic;
+    signal L2_11, K4_10, K7_6, K7_8, S3_3, S3_8, L3_4 : std_logic;
 begin
-	-- MMU_2 @B-1:L3_13
-	L2_11 <= (((A15 nor A14) and A13 and HIRES)  -- L2_6
-		or (A10 and PHI_0_7XX))                  -- B2_6
-		and EN80VID;
+    -- MMU_2 @B-1:L3_13
+    L2_11 <= (((A15 nor A14) and A13 and HIRES) -- L2_6
+        or (A10 and PHI_0_7XX))                 -- B2_6
+        and EN80VID;
 
-	K7_8  <= (FLG1 and R_W_N) nor ((not R_W_N) and FLG2);
-	K4_10 <= not K7_8;
-	K7_6  <= (K4_10 and (not L2_11)) nor (L2_11 and PG2);
-	S3_3  <= (not D_FXXX) and PHI_0_1XX_N;
-	S3_8  <= S3_3 and K7_6;
-	L3_4  <= (ALTSTKZP nor S3_3);
+    K7_8  <= (FLG1 and R_W_N) nor ((not R_W_N) and FLG2);
+    K4_10 <= not K7_8;
+    K7_6  <= (K4_10 and (not L2_11)) nor (L2_11 and PG2);
+    S3_3  <= (not D_FXXX) and PHI_0_1XX_N;
+    S3_8  <= S3_3 and K7_6;
+    L3_4  <= (ALTSTKZP nor S3_3);
 
-	SELMB_N <= L3_4 nor S3_8;
+    SELMB_N <= L3_4 nor S3_8;
 end RTL;

--- a/test/IOU/IOU_INTERNALS_TB.vhdl
+++ b/test/IOU/IOU_INTERNALS_TB.vhdl
@@ -21,7 +21,7 @@ architecture IOU_INTERNALS_TEST of IOU_INTERNALS_TB is
             LA0, LA1, LA2, LA3     : in std_logic;
             IKSTRB                 : in std_logic;
             IAKD                   : in std_logic;
-            P_PHI_2   : in std_logic;
+            P_PHI_2                : in std_logic;
 
             HIRESEN_N : out std_logic;
             C040_7_N  : out std_logic;
@@ -107,8 +107,8 @@ begin
     );
 
     process begin
-        IKSTRB <= '0';
-        IAKD <= '0';
+        IKSTRB  <= '0';
+        IAKD    <= '0';
         P_PHI_2 <= '0';
         wait for 1 ns;
         P_PHI_2 <= '1';
@@ -121,8 +121,6 @@ begin
         wait for 1 ns;
         P_PHI_2 <= '1';
         wait for 1 ns;
-
-
         -- HBL --------------------------------------------
         H3 <= '0';
         H4 <= '0';

--- a/test/IOU/IOU_MD7_TB.vhdl
+++ b/test/IOU/IOU_MD7_TB.vhdl
@@ -8,48 +8,48 @@ end IOU_MD7_TB;
 architecture IOU_MD7_TEST of IOU_MD7_TB is
     component IOU_MD7 is
         port (
-            Q3                 : in std_logic;
-            PHI_0              : in std_logic;
-            PRAS_N             : in std_logic;
-            KEYLE              : in std_logic;
-            POC_N              : in std_logic;
-            CLRKEY_N           : in std_logic;
-            RC00X_N            : in std_logic;
-            RC01X_N            : in std_logic;
-            LA : in std_logic_vector(3 downto 0);
-            AKD                : in std_logic;
-            VBL_N              : in std_logic;
-            ITEXT              : in std_logic;
-            MIX                : in std_logic;
-            PG2                : in std_logic;
-            HIRES              : in std_logic;
-            PAYMAR             : in std_logic;
-            S_80COL            : in std_logic;
+            Q3       : in std_logic;
+            PHI_0    : in std_logic;
+            PRAS_N   : in std_logic;
+            KEYLE    : in std_logic;
+            POC_N    : in std_logic;
+            CLRKEY_N : in std_logic;
+            RC00X_N  : in std_logic;
+            RC01X_N  : in std_logic;
+            LA       : in std_logic_vector(3 downto 0);
+            AKD      : in std_logic;
+            VBL_N    : in std_logic;
+            ITEXT    : in std_logic;
+            MIX      : in std_logic;
+            PG2      : in std_logic;
+            HIRES    : in std_logic;
+            PAYMAR   : in std_logic;
+            S_80COL  : in std_logic;
 
             MD7_ENABLE_N : out std_logic;
             MD7          : out std_logic
         );
     end component;
 
-    signal Q3                 : std_logic;
-    signal PHI_0              : std_logic;
-    signal PRAS_N             : std_logic;
-    signal KEYLE              : std_logic;
-    signal POC_N              : std_logic;
-    signal CLRKEY_N           : std_logic;
-    signal RC00X_N            : std_logic;
-    signal RC01X_N            : std_logic;
-    signal LA : std_logic_vector(3 downto 0);
-    signal AKD                : std_logic;
-    signal VBL_N              : std_logic;
-    signal ITEXT              : std_logic;
-    signal MIX                : std_logic;
-    signal PG2                : std_logic;
-    signal HIRES              : std_logic;
-    signal PAYMAR             : std_logic;
-    signal S_80COL            : std_logic;
-    signal MD7_ENABLE_N       : std_logic;
-    signal MD7                : std_logic;
+    signal Q3           : std_logic;
+    signal PHI_0        : std_logic;
+    signal PRAS_N       : std_logic;
+    signal KEYLE        : std_logic;
+    signal POC_N        : std_logic;
+    signal CLRKEY_N     : std_logic;
+    signal RC00X_N      : std_logic;
+    signal RC01X_N      : std_logic;
+    signal LA           : std_logic_vector(3 downto 0);
+    signal AKD          : std_logic;
+    signal VBL_N        : std_logic;
+    signal ITEXT        : std_logic;
+    signal MIX          : std_logic;
+    signal PG2          : std_logic;
+    signal HIRES        : std_logic;
+    signal PAYMAR       : std_logic;
+    signal S_80COL      : std_logic;
+    signal MD7_ENABLE_N : std_logic;
+    signal MD7          : std_logic;
 
 begin
     dut : IOU_MD7 port map(
@@ -61,7 +61,7 @@ begin
         CLRKEY_N     => CLRKEY_N,
         RC00X_N      => RC00X_N,
         RC01X_N      => RC01X_N,
-        LA => LA,
+        LA           => LA,
         AKD          => AKD,
         VBL_N        => VBL_N,
         ITEXT        => ITEXT,
@@ -83,7 +83,7 @@ begin
         PRAS_N  <= '1';
         RC00X_N <= '0';
         RC01X_N <= '1';
-        LA <= "0000";
+        LA      <= "0000";
         wait for 1 ns;
         assert(MD7_ENABLE_N = '1') report "expect MD7_ENABLE_N to be HIGH" severity error;
 
@@ -154,14 +154,14 @@ begin
 
         RC00X_N <= '1';
         RC01X_N <= '0';
-        LA <= "0101";
+        LA      <= "0101";
         wait for 1 ns;
         assert(MD7_ENABLE_N = '0') report "expect MD7_ENABLE_N to be LOW" severity error;
 
         -- Soft switches addressed
         RC00X_N <= '0';
         RC01X_N <= '1';
-        LA <= "0000";
+        LA      <= "0000";
         wait for 1 ns;
         assert(MD7_ENABLE_N = '0') report "expect MD7_ENABLE_N to be LOW" severity error;
 
@@ -172,14 +172,14 @@ begin
 
         RC00X_N <= '1';
         RC01X_N <= '0';
-        LA <= "1111";
+        LA      <= "1111";
         wait for 1 ns;
         assert(MD7_ENABLE_N = '0') report "expect MD7_ENABLE_N to be LOW" severity error;
 
         -- KEY --------------------------------------------
         RC00X_N <= '0';
         RC01X_N <= '1';
-        LA <= "0000";
+        LA      <= "0000";
 
         KEYLE    <= '0';
         CLRKEY_N <= '1';
@@ -218,14 +218,14 @@ begin
         S_80COL <= '0';
 
         -- C010
-        LA <= x"0";
+        LA  <= x"0";
         AKD <= '1';
         wait for 1 ns;
         assert(MD7_ENABLE_N = '0') report "expect MD7_ENABLE_N to be LOW" severity error;
         assert(MD7 = '1') report "MD7 should be HIGH" severity error;
 
         -- C019
-        LA <= x"9";
+        LA    <= x"9";
         AKD   <= '0';
         VBL_N <= '1';
         wait for 1 ns;
@@ -233,7 +233,7 @@ begin
         assert(MD7 = '1') report "MD7 should be HIGH" severity error;
 
         -- C01A
-        LA <= x"A";
+        LA    <= x"A";
         VBL_N <= '0';
         ITEXT <= '1';
         wait for 1 ns;
@@ -241,7 +241,7 @@ begin
         assert(MD7 = '1') report "MD7 should be HIGH" severity error;
 
         -- C01B
-        LA <= x"B";
+        LA    <= x"B";
         ITEXT <= '0';
         MIX   <= '1';
         wait for 1 ns;
@@ -249,7 +249,7 @@ begin
         assert(MD7 = '1') report "MD7 should be HIGH" severity error;
 
         -- C01C
-        LA <= x"C";
+        LA  <= x"C";
         MIX <= '0';
         PG2 <= '1';
         wait for 1 ns;
@@ -257,7 +257,7 @@ begin
         assert(MD7 = '1') report "MD7 should be HIGH" severity error;
 
         -- C01D
-        LA <= x"D";
+        LA    <= x"D";
         PG2   <= '0';
         HIRES <= '1';
         wait for 1 ns;
@@ -265,7 +265,7 @@ begin
         assert(MD7 = '1') report "MD7 should be HIGH" severity error;
 
         -- C01E
-        LA <= x"E";
+        LA     <= x"E";
         HIRES  <= '0';
         PAYMAR <= '1';
         wait for 1 ns;
@@ -273,7 +273,7 @@ begin
         assert(MD7 = '1') report "MD7 should be HIGH" severity error;
 
         -- C01F
-        LA <= x"F";
+        LA      <= x"F";
         PAYMAR  <= '0';
         S_80COL <= '1';
         wait for 1 ns;

--- a/test/IOU/IOU_RESET_TB.vhdl
+++ b/test/IOU/IOU_RESET_TB.vhdl
@@ -19,18 +19,18 @@ architecture IOU_RESET_TEST of IOU_RESET_TB is
     signal PHI_1             : std_logic;
     signal TC                : std_logic;
     signal FORCE_RESET_N_LOW : std_logic;
-    signal POC_N               : std_logic;
+    signal POC_N             : std_logic;
 
 begin
     dut : IOU_RESET port map(
         PHI_1             => PHI_1,
         TC                => TC,
-        POC_N               => POC_N,
+        POC_N             => POC_N,
         FORCE_RESET_N_LOW => FORCE_RESET_N_LOW
     );
 
     process begin
-        TC <= '0';
+        TC    <= '0';
         POC_N <= '0';
         wait for 490 ns;
         assert(FORCE_RESET_N_LOW = '1') report "expect FORCE_RESET_N_LOW HIGH" severity error;

--- a/test/IOU/VIDEO_GENERATOR_TB.vhdl
+++ b/test/IOU/VIDEO_GENERATOR_TB.vhdl
@@ -249,7 +249,7 @@ begin
 
         P_PHI_1 <= '1';
         wait for 1 ns;
-        assert(CLRGAT_N = '0') report "expect CLRGAT_N LOW" severity error;
+        assert(CLRGAT_N = '1') report "expect CLRGAT_N HIGH" severity error;
 
         P_PHI_1 <= '0';
         wait for 1 ns;
@@ -257,7 +257,7 @@ begin
         P_PHI_1 <= '1';
         PCLRGAT <= '1';
         wait for 1 ns;
-        assert(CLRGAT_N = '1') report "expect CLRGAT_N HIGH" severity error;
+        assert(CLRGAT_N = '0') report "expect CLRGAT_N LOW" severity error;
 
         -- SYNC_N ---------------------------------------
         P_PHI_1 <= '0';

--- a/test/IOU/test_cases/mocks/POWER_ON_DETECTION_MOCK.vhdl
+++ b/test/IOU/test_cases/mocks/POWER_ON_DETECTION_MOCK.vhdl
@@ -5,7 +5,7 @@ use work.IOU_TESTBENCH_PACKAGE.all;
 entity POWER_ON_DETECTION_MOCK is
     port (
         PHI_0 : in std_logic;
-        POC_N  : out std_logic
+        POC_N : out std_logic
     );
 end POWER_ON_DETECTION_MOCK;
 


### PR DESCRIPTION
Fixes https://github.com/frozen-signal/Apple_IIe_MMU_IOU/issues/3

See R7 on IOU_1 at B-2:
The output of pin 1 on a 74LS75 is the input inverted. The inversion was missing.

Also:
Reformated some files.
