### PR TITLE
Fixed DRAM /RAS hold time

### DIFF
--- a/COMMON/RA_MUX.vhdl
+++ b/COMMON/RA_MUX.vhdl
@@ -1,0 +1,37 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+
+entity RA_MUX is
+    port (
+        Q3_PRAS_N      : in std_logic;
+        PRAS_N         : in std_logic;
+        RAS_N          : in std_logic;  -- The delayed PRAS_N signal. See comment below.
+        P_PHI          : in std_logic;
+        ROW_RA0, ROW_RA1, ROW_RA2, ROW_RA3,
+        ROW_RA4, ROW_RA5, ROW_RA6, ROW_RA7 : in std_logic;
+        COL_RA0, COL_RA1, COL_RA2, COL_RA3,
+        COL_RA4, COL_RA5, COL_RA6, COL_RA7 : in std_logic;
+
+        RA_ENABLE_N        : out std_logic;
+        RA0, RA1, RA2, RA3,
+        RA4, RA5, RA6, RA7 : out std_logic
+    );
+end RA_MUX;
+
+architecture RTL of RA_MUX is
+begin
+    RA_ENABLE_N <= Q3_PRAS_N nand P_PHI;
+
+    -- The Apple IIe RAM reads ROW address on the falling edge of PRAS_N and requires to hold that address for
+    -- a certain delay (t_RAH in the datasheets; 25ns in the case of the 4564-20 DRAM). So we set the ROW before
+    -- the falling edge of PRAS_N and hold it for as long as RAS_N is HIGH.
+    RA0 <= ROW_RA0 when RAS_N = '1' else COL_RA0;
+    RA1 <= ROW_RA1 when RAS_N = '1' else COL_RA1;
+    RA2 <= ROW_RA2 when RAS_N = '1' else COL_RA2;
+    RA3 <= ROW_RA3 when RAS_N = '1' else COL_RA3;
+    RA4 <= ROW_RA4 when RAS_N = '1' else COL_RA4;
+    RA5 <= ROW_RA5 when RAS_N = '1' else COL_RA5;
+    RA6 <= ROW_RA6 when RAS_N = '1' else COL_RA6;
+    RA7 <= ROW_RA7 when RAS_N = '1' else COL_RA7;
+
+end RTL;

--- a/CUSTOM/POWER_ON_DETECTION.vhdl
+++ b/CUSTOM/POWER_ON_DETECTION.vhdl
@@ -2,8 +2,9 @@ library IEEE;
 use IEEE.std_logic_1164.all;
 use ieee.numeric_std.all;
 
--- When the computer is powered on, POC is used to detect the power-on event. This is what is described on MMU_1:
+-- When the computer is powered on, the POC signal is used to detect the power-on event.
 --
+-- This is what is described on MMU_1:
 -- The circuits at B-3:A3-2 and the 555 timer at B-2:B3 are a power-on detection circuit. That
 -- circuit will hold POC HIGH for about 300ms, then drive POC LOW. When that happens other circuits will
 -- be allowed to initialize (See IOU_RESET). During that time, RESET_N is held LOW.

--- a/CUSTOM/RAS_HOLD_TIME/RAS_HOLD_TIME_ALTERA.vhdl
+++ b/CUSTOM/RAS_HOLD_TIME/RAS_HOLD_TIME_ALTERA.vhdl
@@ -1,0 +1,46 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- NOTE: This implementation of RAS_HOLD_TIME can only be used with Altera devices that support the LCELL primitive.
+entity RAS_HOLD_TIME_ALTERA is
+    port (
+        PRAS_N : in std_logic;
+
+        RAS_N : out std_logic
+    );
+end RAS_HOLD_TIME_ALTERA;
+
+architecture RTL of RAS_HOLD_TIME_ALTERA is
+    component LCELL
+        port (
+            A_IN : in std_logic;
+            A_OUT : out std_logic
+        );
+    end component;
+
+    signal PRAS_N_5NS, PRAS_N_10NS, PRAS_N_15NS, PRAS_N_20NS, PRAS_N_25NS : std_logic;
+begin
+    DELAY_5NS : LCELL port map(
+        A_IN => PRAS_N,
+        A_OUT => PRAS_N_5NS
+    );
+    DELAY_10NS : LCELL port map(
+        A_IN => PRAS_N_5NS,
+        A_OUT => PRAS_N_10NS
+    );
+    DELAY_15NS : LCELL port map(
+        A_IN => PRAS_N_10NS,
+        A_OUT => PRAS_N_15NS
+    );
+    DELAY_20NS : LCELL port map(
+        A_IN => PRAS_N_15NS,
+        A_OUT => PRAS_N_20NS
+    );
+    DELAY_25NS : LCELL port map(
+        A_IN => PRAS_N_20NS,
+        A_OUT => PRAS_N_25NS
+    );
+
+    RAS_N <= PRAS_N_25NS;
+end RTL;

--- a/CUSTOM/RAS_HOLD_TIME/RAS_HOLD_TIME_TEST.vhdl
+++ b/CUSTOM/RAS_HOLD_TIME/RAS_HOLD_TIME_TEST.vhdl
@@ -1,0 +1,17 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- NOTE: This implementation of RAS_HOLD_TIME should only be used in simulation.
+entity RAS_HOLD_TIME_TEST is
+    port (
+        PRAS_N : in std_logic;
+
+        RAS_N : out std_logic
+    );
+end RAS_HOLD_TIME_TEST;
+
+architecture RTL of RAS_HOLD_TIME_TEST is
+begin
+    RAS_N <= PRAS_N;
+end RTL;

--- a/CUSTOM/RAS_HOLD_TIME/readme.md
+++ b/CUSTOM/RAS_HOLD_TIME/readme.md
@@ -1,0 +1,11 @@
+This directory contains few implementations of RAS_HOLD_TIME.
+
+####RAS_HOLD_TIME_TEST
+This is only used with the testbenches. This implementation do not add the required delay.
+
+####RAS_HOLD_TIME_ALTERA
+This can be used with Altera FPGA/CPLDs that support the LCELL primitive.
+
+####Specifications
+An implementation need to delay the PRAS_N signal by at least 25ns and return the delayed signal with RAS_N.
+

--- a/CUSTOM/readme.md
+++ b/CUSTOM/readme.md
@@ -1,0 +1,12 @@
+This directory contains all the components that may need to be changed depending on the hardware used.
+
+### Summary of Components:
+####POWER_ON_DETECTION
+A component that drives a signal HIGH when power-on event is detected, keep it high for 2.4 milisecond, and then drives it LOW for as long as the Apple IIe has power.
+<br/>
+**Need to be modified if** your FPGA/CPLD do not initialize flip-flops and other memory elements at '0' on power-on.
+
+####RAS_HOLD_TIME
+A component that adds a 25ns delay to PRAS_N. Required by the Apple IIe's multiplexed DRAM.
+<br/>
+**Presently only ALTERA devices are supported.** More devices will be added later.

--- a/IOU/IOU.vhdl
+++ b/IOU/IOU.vhdl
@@ -39,6 +39,22 @@ end IOU;
 architecture RTL of IOU is
     constant NTSC : std_logic := '1'; -- FIXME: How should options be handled? Input pin? Leave as constant?
 
+    -- FIXME: Use generics to switch
+    -- component RAS_HOLD_TIME_ALTERA is
+    --     port (
+    --         PRAS_N : in std_logic;
+
+    --         RAS_N : out std_logic
+    --     );
+    -- end component;
+    component RAS_HOLD_TIME_TEST is
+        port (
+            PRAS_N : in std_logic;
+
+            RAS_N : out std_logic
+        );
+    end component;
+
     component POWER_ON_DETECTION is
         port (
             PHI_0 : in std_logic;
@@ -238,6 +254,7 @@ architecture RTL of IOU is
             VA, VB, VC     : in std_logic;
             Q3_PRAS_N      : in std_logic;
             PRAS_N         : in std_logic;
+            RAS_N          : in std_logic;
             P_PHI_1        : in std_logic;
             V0, V1, V2     : in std_logic;
             H0, H1, H2     : in std_logic;
@@ -324,6 +341,7 @@ architecture RTL of IOU is
         );
     end component;
 
+    signal RAS_N : std_logic;
     signal RC01X_N, P_PHI_0, P_PHI_1, Q3_PRAS_N                                                   : std_logic;
     signal P_PHI_2, PHI_1, CTC14S                                                                 : std_logic;
     signal FORCE_RESET_N_LOW, RESET_N, IN_RESET                                                   : std_logic;
@@ -345,6 +363,15 @@ architecture RTL of IOU is
 
     signal H0_INT, LGR_TXT_N_INT, ORA7_INT : std_logic;
 begin
+    -- U_RAS_HOLD_TIME : RAS_HOLD_TIME_ALTERA port map(
+    --     PRAS_N => PRAS_N,
+    --     RAS_N => RAS_N
+    -- );
+    U_RAS_HOLD_TIME : RAS_HOLD_TIME_TEST port map(
+        PRAS_N => PRAS_N,
+        RAS_N => RAS_N
+    );
+
     U_POWER_ON_DETECTION : POWER_ON_DETECTION port map(
         PHI_0 => PHI_0,
         POC_N => POC_N
@@ -577,6 +604,7 @@ begin
         VC          => VC,
         Q3_PRAS_N   => Q3_PRAS_N,
         PRAS_N      => PRAS_N,
+        RAS_N       => RAS_N,
         P_PHI_1     => P_PHI_1,
         V0          => V0,
         V1          => V1,

--- a/IOU/VIDEO_ADDR_MUX.vhdl
+++ b/IOU/VIDEO_ADDR_MUX.vhdl
@@ -9,6 +9,7 @@ entity VIDEO_ADDR_MUX is
         VA, VB, VC     : in std_logic;
         Q3_PRAS_N      : in std_logic;
         PRAS_N         : in std_logic;
+        RAS_N          : in std_logic;
         P_PHI_1        : in std_logic;
         V0, V1, V2     : in std_logic;
         H0, H1, H2     : in std_logic;
@@ -22,10 +23,64 @@ entity VIDEO_ADDR_MUX is
 end VIDEO_ADDR_MUX;
 
 architecture RTL of VIDEO_ADDR_MUX is
-    signal VID_PG2_N : std_logic;
+    component RA_MUX is
+        port (
+            Q3_PRAS_N      : in std_logic;
+            PRAS_N         : in std_logic;
+            RAS_N          : in std_logic;  -- RAS_N is PRAS_N delayed by t_RAH (for example, t_RAH is 25 ns for the 4564-20 DRAM)
+            P_PHI          : in std_logic;
+            ROW_RA0, ROW_RA1, ROW_RA2, ROW_RA3,
+            ROW_RA4, ROW_RA5, ROW_RA6, ROW_RA7 : in std_logic;
+            COL_RA0, COL_RA1, COL_RA2, COL_RA3,
+            COL_RA4, COL_RA5, COL_RA6, COL_RA7 : in std_logic;
 
+            RA_ENABLE_N        : out std_logic;
+            RA0, RA1, RA2, RA3,
+            RA4, RA5, RA6, RA7 : out std_logic
+        );
+    end component;
+
+    signal VID_PG2_N : std_logic;
     signal ZA_INT, ZB_INT, ZC_INT, ZD_INT, ZE_INT : std_logic;
 begin
+    IOU_RA_MUX : RA_MUX port map(
+        Q3_PRAS_N => Q3_PRAS_N,
+        PRAS_N => PRAS_N,
+        RAS_N => RAS_N,
+        P_PHI => P_PHI_1,
+
+        -- IOU_1 @C-D-3:A9 & B9
+        -- The inputs of the LS257 are incorrect on the schematics. Doulble-checked against
+        -- "Understanding the Apple IIe" by Jim Sather, p.5-8
+        -- and "Apple II reference manual for //e only", p.157
+        ROW_RA0 => H0,
+        ROW_RA1 => H1,
+        ROW_RA2 => H2,
+        ROW_RA3 => E0,
+        ROW_RA4 => E1,
+        ROW_RA5 => E2,
+        ROW_RA6 => E3,
+        ROW_RA7 => V0,
+        COL_RA0 => V1,
+        COL_RA1 => V2,
+        COL_RA2 => ZA_INT,
+        COL_RA3 => ZB_INT,
+        COL_RA4 => ZC_INT,
+        COL_RA5 => ZD_INT,
+        COL_RA6 => ZE_INT, -- ZE/V1 has been simplified to ZE since bonding option 64K is always high
+        COL_RA7 => '0',
+
+        RA_ENABLE_N => RA_ENABLE_N,  -- IOU_1 @D-3:A9
+        RA0 => RA0,
+        RA1 => RA1,
+        RA2 => RA2,
+        RA3 => RA3,
+        RA4 => RA4,
+        RA5 => RA5,
+        RA6 => RA6,
+        RA7 => RA7
+    );
+
     -- IOU_2 @C-4:E2-8
     VID_PG2_N <= PG2_N or EN80VID;
     ZA_INT    <= VA when HIRESEN_N = '0' else VID_PG2_N;
@@ -33,23 +88,6 @@ begin
     ZC_INT    <= VC when HIRESEN_N = '0' else '0';
     ZD_INT    <= VID_PG2_N when HIRESEN_N = '0' else '0';
     ZE_INT    <= HIRESEN_N nor VID_PG2_N; -- IOU_2 @A-4:L9-4
-
-    -- IOU_1 @D-3:A9
-    RA_ENABLE_N <= Q3_PRAS_N nand P_PHI_1;
-
-    -- IOU_1 @C-D-3:A9 & B9
-    -- The inputs of the LS257 are incorrect on the schematics. Doulble-checked against
-    -- "Understanding the Apple IIe" by Jim Sather, p.5-8
-    -- and "Apple II reference manual for //e only", p.157
-    RA0 <= H0 when PRAS_N = '1' else V1;
-    RA1 <= H1 when PRAS_N = '1' else V2;
-    RA2 <= H2 when PRAS_N = '1' else ZA_INT;
-    RA3 <= E0 when PRAS_N = '1' else ZB_INT;
-
-    RA4 <= E1 when PRAS_N = '1' else ZC_INT;
-    RA5 <= E2 when PRAS_N = '1' else ZD_INT;
-    RA6 <= E3 when PRAS_N = '1' else ZE_INT; -- ZE/V1 has been simplified to ZE since bonding option 64K is always high
-    RA7 <= V0 when PRAS_N = '1' else '0';
 
     ZA <= ZA_INT;
     ZB <= ZB_INT;

--- a/MMU/MMU_RA.vhdl
+++ b/MMU/MMU_RA.vhdl
@@ -5,34 +5,71 @@ entity MMU_RA is
     port (
         A         : in std_logic_vector(15 downto 0);
         PRAS_N    : in std_logic;
+        RAS_N     : in std_logic;
         P_PHI_0   : in std_logic;
         Q3_PRAS_N : in std_logic;
         DXXX_N    : in std_logic;
         BANK1     : in std_logic;
 
-        RA       : out std_logic_vector(7 downto 0);
-        ENABLE_N : out std_logic
+        RA          : out std_logic_vector(7 downto 0);
+        RA_ENABLE_N : out std_logic
     );
 end MMU_RA;
 
 architecture RTL of MMU_RA is
+    component RA_MUX is
+        port (
+            Q3_PRAS_N : in std_logic;
+            PRAS_N    : in std_logic;
+            RAS_N     : in std_logic; -- RAS_N is PRAS_N delayed by t_RAH (for example, t_RAH is 25 ns for the 4564-20 DRAM)
+            P_PHI     : in std_logic;
+            ROW_RA0, ROW_RA1, ROW_RA2, ROW_RA3,
+            ROW_RA4, ROW_RA5, ROW_RA6, ROW_RA7 : in std_logic;
+            COL_RA0, COL_RA1, COL_RA2, COL_RA3,
+            COL_RA4, COL_RA5, COL_RA6, COL_RA7 : in std_logic;
+
+            RA_ENABLE_N : out std_logic;
+            RA0, RA1, RA2, RA3,
+            RA4, RA5, RA6, RA7 : out std_logic
+        );
+    end component;
+
     signal MA12 : std_logic;
 begin
     -- MMU_2 @C-4:H4-6
     MA12 <= ((not DXXX_N) and BANK1) xor A(12);
+    IOU_RA_MUX : RA_MUX port map(
+        Q3_PRAS_N => Q3_PRAS_N,
+        PRAS_N    => PRAS_N,
+        RAS_N     => RAS_N,
+        P_PHI     => P_PHI_0,
 
-    -- MMU_1 @C-4:E3-8
-    ENABLE_N <= P_PHI_0 nand Q3_PRAS_N;
+        -- MMU_1 @ @C-4:E5 and D5
+        ROW_RA0 => A(0),
+        ROW_RA1 => A(1),
+        ROW_RA2 => A(2),
+        ROW_RA3 => A(3),
+        ROW_RA4 => A(4),
+        ROW_RA5 => A(5),
+        ROW_RA6 => A(7),
+        ROW_RA7 => A(8),
+        COL_RA0 => A(9),
+        COL_RA1 => A(6),
+        COL_RA2 => A(10),
+        COL_RA3 => A(11),
+        COL_RA4 => MA12,
+        COL_RA5 => A(13),
+        COL_RA6 => A(14), -- We consider 64K to be always HIGH
+        COL_RA7 => A(15),
 
-    -- MMU_1 @ @C-4:E5
-    RA(0) <= A(0) when PRAS_N = '1' else A(9);
-    RA(1) <= A(1) when PRAS_N = '1' else A(6);
-    RA(2) <= A(2) when PRAS_N = '1' else A(10);
-    RA(3) <= A(3) when PRAS_N = '1' else A(11);
-
-    -- MMU_1 @ @C-4:D5
-    RA(4) <= A(4) when PRAS_N = '1' else MA12;
-    RA(5) <= A(5) when PRAS_N = '1' else A(13);
-    RA(6) <= A(7) when PRAS_N = '1' else A(14); -- We consider 64K to be always HIGH
-    RA(7) <= A(8) when PRAS_N = '1' else A(15);
+        RA_ENABLE_N => RA_ENABLE_N, -- MMU_1 @C-4:E3-8
+        RA0         => RA(0),
+        RA1         => RA(1),
+        RA2         => RA(2),
+        RA3         => RA(3),
+        RA4         => RA(4),
+        RA5         => RA(5),
+        RA6         => RA(6),
+        RA7         => RA(7)
+    );
 end RTL;

--- a/make.sh
+++ b/make.sh
@@ -1,2 +1,2 @@
-find . -print -type d | grep \.vhdl$ | xargs -n 1 ghdl -i --workdir=work
-find . -print -type d | grep \.vhdl$ | xargs -n 1 basename --suffix=.vhdl | xargs -n 1 ghdl -m --workdir=work
+find . -print -type d | grep \.vhdl$ | grep -v _ALTERA\.vhdl$ | xargs -n 1 ghdl -i --workdir=work
+find . -print -type d | grep \.vhdl$ | grep -v _ALTERA\.vhdl$ | xargs -n 1 basename --suffix=.vhdl | xargs -n 1 ghdl -m --workdir=work

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 Note: This project is currently under development.<br/>
-![IOU](https://img.shields.io/badge/IOU-Non_Functionnal-red)<br/>
+![IOU](https://img.shields.io/badge/IOU-Partially_Functionnal-yellow)<br/>
 ![MMU](https://img.shields.io/badge/MMU-Partially_Functionnal-yellow)<br/>
 
 
@@ -41,6 +41,7 @@ And all testbenches can be simulated with this command:
 
 # Directory Structure
 * **COMMON**: Components common to the MMU and the IOU.
+* **CUSTOM**: Components that may need to be changed depending on the hardware used.
 * **TTL**: Implementation of a few TTL components used in the schematics.
 * **MMU**: Components that makes the MMU.
 * **IOU**: Components that makes the IOU.

--- a/test/COMMON/RA_MUX_TB.vhdl
+++ b/test/COMMON/RA_MUX_TB.vhdl
@@ -1,0 +1,169 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+
+entity RA_MUX_TB is
+    -- empty
+end RA_MUX_TB;
+
+architecture RA_MUX_TEST of RA_MUX_TB is
+    component RA_MUX is
+        port (
+            Q3_PRAS_N : in std_logic;
+            PRAS_N    : in std_logic;
+            RAS_N     : in std_logic;
+            P_PHI     : in std_logic;
+            ROW_RA0, ROW_RA1, ROW_RA2, ROW_RA3,
+            ROW_RA4, ROW_RA5, ROW_RA6, ROW_RA7 : in std_logic;
+            COL_RA0, COL_RA1, COL_RA2, COL_RA3,
+            COL_RA4, COL_RA5, COL_RA6, COL_RA7 : in std_logic;
+
+            RA_ENABLE_N : out std_logic;
+            RA0, RA1, RA2, RA3,
+            RA4, RA5, RA6, RA7 : out std_logic
+        );
+    end component;
+
+    signal Q3_PRAS_N : std_logic;
+    signal PRAS_N    : std_logic;
+    signal RAS_N     : std_logic;
+    signal P_PHI     : std_logic;
+    signal ROW_RA0, ROW_RA1, ROW_RA2, ROW_RA3,
+    ROW_RA4, ROW_RA5, ROW_RA6, ROW_RA7 : std_logic;
+    signal COL_RA0, COL_RA1, COL_RA2, COL_RA3,
+    COL_RA4, COL_RA5, COL_RA6, COL_RA7 : std_logic;
+
+    signal RA_ENABLE_N : std_logic;
+    signal RA0, RA1, RA2, RA3,
+    RA4, RA5, RA6, RA7 : std_logic;
+begin
+    dut : RA_MUX port map(
+        Q3_PRAS_N => Q3_PRAS_N,
+        PRAS_N => PRAS_N,
+        RAS_N => RAS_N,
+        P_PHI => P_PHI,
+        ROW_RA0 => ROW_RA0,
+        ROW_RA1 => ROW_RA1,
+        ROW_RA2 => ROW_RA2,
+        ROW_RA3 => ROW_RA3,
+        ROW_RA4 => ROW_RA4,
+        ROW_RA5 => ROW_RA5,
+        ROW_RA6 => ROW_RA6,
+        ROW_RA7 => ROW_RA7,
+        COL_RA0 => COL_RA0,
+        COL_RA1 => COL_RA1,
+        COL_RA2 => COL_RA2,
+        COL_RA3 => COL_RA3,
+        COL_RA4 => COL_RA4,
+        COL_RA5 => COL_RA5,
+        COL_RA6 => COL_RA6,
+        COL_RA7 => COL_RA7,
+
+        RA_ENABLE_N => RA_ENABLE_N,
+        RA0 => RA0,
+        RA1 => RA1,
+        RA2 => RA2,
+        RA3 => RA3,
+        RA4 => RA4,
+        RA5 => RA5,
+        RA6 => RA6,
+        RA7 => RA7
+
+    );
+
+    process begin
+        ROW_RA0 <= '0';
+        ROW_RA1 <= '1';
+        ROW_RA2 <= '0';
+        ROW_RA3 <= '1';
+        ROW_RA4 <= '0';
+        ROW_RA5 <= '1';
+        ROW_RA6 <= '0';
+        ROW_RA7 <= '1';
+        COL_RA0 <= 'U';
+        COL_RA1 <= 'U';
+        COL_RA2 <= 'U';
+        COL_RA3 <= 'U';
+        COL_RA4 <= 'U';
+        COL_RA5 <= 'U';
+        COL_RA6 <= 'U';
+        COL_RA7 <= 'U';
+
+        PRAS_N <= '1';
+        RAS_N <= '1';
+        wait for 1 ns;
+        assert(RA0 = '0') report "When PRAS_N is HIGH and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA1 = '1') report "When PRAS_N is HIGH and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA2 = '0') report "When PRAS_N is HIGH and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA3 = '1') report "When PRAS_N is HIGH and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA4 = '0') report "When PRAS_N is HIGH and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA5 = '1') report "When PRAS_N is HIGH and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA6 = '0') report "When PRAS_N is HIGH and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA7 = '1') report "When PRAS_N is HIGH and RAS_N is HIGH, RA should be ROW addresses" severity error;
+
+        PRAS_N <= '0';
+        RAS_N <= '1';
+        wait for 1 ns;
+        assert(RA0 = '0') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA1 = '1') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA2 = '0') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA3 = '1') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA4 = '0') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA5 = '1') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA6 = '0') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA7 = '1') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
+
+        ROW_RA0 <= 'U';
+        ROW_RA1 <= 'U';
+        ROW_RA2 <= 'U';
+        ROW_RA3 <= 'U';
+        ROW_RA4 <= 'U';
+        ROW_RA5 <= 'U';
+        ROW_RA6 <= 'U';
+        ROW_RA7 <= 'U';
+        COL_RA0 <= '0';
+        COL_RA1 <= '1';
+        COL_RA2 <= '0';
+        COL_RA3 <= '1';
+        COL_RA4 <= '0';
+        COL_RA5 <= '1';
+        COL_RA6 <= '0';
+        COL_RA7 <= '1';
+
+        PRAS_N <= '0';
+        RAS_N <= '0';
+        wait for 1 ns;
+        assert(RA0 = '0') report "When PRAS_N is LOW and RAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA1 = '1') report "When PRAS_N is LOW and RAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA2 = '0') report "When PRAS_N is LOW and RAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA3 = '1') report "When PRAS_N is LOW and RAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA4 = '0') report "When PRAS_N is LOW and RAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA5 = '1') report "When PRAS_N is LOW and RAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA6 = '0') report "When PRAS_N is LOW and RAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA7 = '1') report "When PRAS_N is LOW and RAS_N is LOW, RA should be COL addresses" severity error;
+
+
+        Q3_PRAS_N <= '0';
+        P_PHI <= '0';
+        wait for 1 ns;
+        assert(RA_ENABLE_N = '1') report "When Q3_PRAS_N is LOW and P_PHI is LOW, RA_ENABLE_N should be HIGH" severity error;
+
+        Q3_PRAS_N <= '0';
+        P_PHI <= '1';
+        wait for 1 ns;
+        assert(RA_ENABLE_N = '1') report "When Q3_PRAS_N is LOW and P_PHI is HIGH, RA_ENABLE_N should be HIGH" severity error;
+
+        Q3_PRAS_N <= '1';
+        P_PHI <= '0';
+        wait for 1 ns;
+        assert(RA_ENABLE_N = '1') report "When Q3_PRAS_N is HIGH and P_PHI is LOW, RA_ENABLE_N should be HIGH" severity error;
+
+        Q3_PRAS_N <= '1';
+        P_PHI <= '1';
+        wait for 1 ns;
+        assert(RA_ENABLE_N = '0') report "When Q3_PRAS_N is HIGH and P_PHI is HIGH, RA_ENABLE_N should be LOW" severity error;
+
+        assert false report "Test done." severity note;
+        wait;
+
+    end process;
+end RA_MUX_TEST;

--- a/test/IOU/VIDEO_ADDR_MUX_TB.vhdl
+++ b/test/IOU/VIDEO_ADDR_MUX_TB.vhdl
@@ -14,6 +14,7 @@ architecture VIDEO_ADDR_MUX_TEST of VIDEO_ADDR_MUX_TB is
             VA, VB, VC     : in std_logic;
             Q3_PRAS_N      : in std_logic;
             PRAS_N         : in std_logic;
+            RAS_N          : in std_logic;
             P_PHI_1        : in std_logic;
             V0, V1, V2     : in std_logic;
             H0, H1, H2     : in std_logic;
@@ -32,6 +33,7 @@ architecture VIDEO_ADDR_MUX_TEST of VIDEO_ADDR_MUX_TB is
     signal VA, VB, VC     : std_logic;
     signal Q3_PRAS_N      : std_logic;
     signal PRAS_N         : std_logic;
+    signal RAS_N          : std_logic;
     signal P_PHI_1        : std_logic;
     signal V0, V1, V2     : std_logic;
     signal H0, H1, H2     : std_logic;
@@ -52,6 +54,7 @@ begin
         VC          => VC,
         Q3_PRAS_N   => Q3_PRAS_N,
         PRAS_N      => PRAS_N,
+        RAS_N       => PRAS_N,  -- We don't test the ROW hold time; we simply use PRAS_N without the delay
         P_PHI_1     => P_PHI_1,
         V0          => V0,
         V1          => V1,
@@ -185,15 +188,15 @@ begin
         VB        <= 'U';
         VC        <= 'U';
         V2        <= 'U';
-        E3        <= '1';
         H0        <= '1';
         H1        <= '1';
         H2        <= '1';
         E0        <= '1';
         E1        <= '1';
         E2        <= '1';
+        E3        <= '1';
         V0        <= '1';
-        V1        <= '1';
+        V1        <= 'U';
         EN80VID   <= 'U';
         HIRESEN_N <= 'U';
         PG2_N     <= 'U';
@@ -205,7 +208,7 @@ begin
         assert(RA4 = '1') report "expect RA4 HIGH" severity error;
         assert(RA5 = '1') report "expect RA5 HIGH" severity error;
         assert(RA6 = '1') report "expect RA6 HIGH" severity error;
-        assert(RA7 = '1') report "expect RA7 LOW" severity error;
+        assert(RA7 = '1') report "expect RA7 HIGH" severity error;
 
         assert false report "Test done." severity note;
         wait;

--- a/test/IOU/test_cases/mocks/CPU_MMU_MOCK.vhdl
+++ b/test/IOU/test_cases/mocks/CPU_MMU_MOCK.vhdl
@@ -31,13 +31,14 @@ architecture MOCK of CPU_MMU_MOCK is
         port (
             A         : in std_logic_vector(15 downto 0);
             PRAS_N    : in std_logic;
+            RAS_N     : in std_logic;
             P_PHI_0   : in std_logic;
             Q3_PRAS_N : in std_logic;
             DXXX_N    : in std_logic;
             BANK1     : in std_logic;
 
-            RA       : out std_logic_vector(7 downto 0);
-            ENABLE_N : out std_logic
+            RA          : out std_logic_vector(7 downto 0);
+            RA_ENABLE_N : out std_logic
         );
     end component;
 
@@ -73,13 +74,14 @@ begin
     );
 
     U_MMU_RA : MMU_RA port map(
-        A         => "0000000000000000",
-        PRAS_N    => '0',
-        P_PHI_0   => P_PHI_0,
-        Q3_PRAS_N => Q3_PRAS_N,
-        DXXX_N    => '0',
-        BANK1     => '0',
-        ENABLE_N  => RA_ENABLE_N
+        A           => "0000000000000000",
+        PRAS_N      => '0',
+        RAS_N       => '0',
+        P_PHI_0     => P_PHI_0,
+        Q3_PRAS_N   => Q3_PRAS_N,
+        DXXX_N      => '0',
+        BANK1       => '0',
+        RA_ENABLE_N => RA_ENABLE_N
     );
 
     process (PHI_0, Q3, PRAS_N)

--- a/test/IOU/test_cases/mocks/VIDEO_ADDR_MUX_SPY.vhdl
+++ b/test/IOU/test_cases/mocks/VIDEO_ADDR_MUX_SPY.vhdl
@@ -10,6 +10,7 @@ entity VIDEO_ADDR_MUX_SPY is
         VA, VB, VC     : in std_logic;
         Q3_PRAS_N      : in std_logic;
         PRAS_N         : in std_logic;
+        RAS_N          : in std_logic;
         P_PHI_1        : in std_logic;
         V0, V1, V2     : in std_logic;
         H0, H1, H2     : in std_logic;
@@ -31,6 +32,7 @@ architecture SPY of VIDEO_ADDR_MUX_SPY is
             VA, VB, VC     : in std_logic;
             Q3_PRAS_N      : in std_logic;
             PRAS_N         : in std_logic;
+            RAS_N          : in std_logic;
             P_PHI_1        : in std_logic;
             V0, V1, V2     : in std_logic;
             H0, H1, H2     : in std_logic;
@@ -55,6 +57,7 @@ begin
         VC          => VC,
         Q3_PRAS_N   => Q3_PRAS_N,
         PRAS_N      => PRAS_N,
+        RAS_N       => RAS_N,
         P_PHI_1     => P_PHI_1,
         V0          => V0,
         V1          => V1,

--- a/test/MMU/MMU_RA_TB.vhdl
+++ b/test/MMU/MMU_RA_TB.vhdl
@@ -9,13 +9,14 @@ architecture MMU_RA_TEST of MMU_RA_TB is
         port (
             A         : in std_logic_vector(15 downto 0);
             PRAS_N    : in std_logic;
+            RAS_N     : in std_logic;
             P_PHI_0   : in std_logic;
             Q3_PRAS_N : in std_logic;
             DXXX_N    : in std_logic;
             BANK1     : in std_logic;
 
             RA       : out std_logic_vector(7 downto 0);
-            ENABLE_N : out std_logic
+            RA_ENABLE_N : out std_logic
         );
     end component;
 
@@ -26,40 +27,41 @@ architecture MMU_RA_TEST of MMU_RA_TB is
     signal DXXX_N    : std_logic;
     signal BANK1     : std_logic;
     signal RA        : std_logic_vector(7 downto 0);
-    signal ENABLE_N  : std_logic;
+    signal RA_ENABLE_N  : std_logic;
 
 begin
     dut : MMU_RA port map(
         A         => A,
         PRAS_N    => PRAS_N,
+        RAS_N     => PRAS_N, -- We don't test the ROW hold time; we simply use PRAS_N without the delay
         P_PHI_0   => P_PHI_0,
         Q3_PRAS_N => Q3_PRAS_N,
         DXXX_N    => DXXX_N,
         BANK1     => BANK1,
         RA        => RA,
-        ENABLE_N  => ENABLE_N
+        RA_ENABLE_N  => RA_ENABLE_N
     );
 
     process begin
         P_PHI_0   <= '1';
         Q3_PRAS_N <= '1';
         wait for 1 ns;
-        assert(ENABLE_N = '0') report "When P_PHI_0 and Q3_PRAS_N are HIGH; expect ENABLE LOW" severity error;
+        assert(RA_ENABLE_N = '0') report "When P_PHI_0 and Q3_PRAS_N are HIGH; expect ENABLE LOW" severity error;
 
         P_PHI_0   <= '0';
         Q3_PRAS_N <= '1';
         wait for 1 ns;
-        assert(ENABLE_N = '1') report "When P_PHI_0 is LOW and Q3_PRAS_N is HIGH; expect ENABLE HIGH" severity error;
+        assert(RA_ENABLE_N = '1') report "When P_PHI_0 is LOW and Q3_PRAS_N is HIGH; expect ENABLE HIGH" severity error;
 
         P_PHI_0   <= '1';
         Q3_PRAS_N <= '0';
         wait for 1 ns;
-        assert(ENABLE_N = '1') report "When P_PHI_0 is HIGH and Q3_PRAS_N is LOW; expect ENABLE HIGH" severity error;
+        assert(RA_ENABLE_N = '1') report "When P_PHI_0 is HIGH and Q3_PRAS_N is LOW; expect ENABLE HIGH" severity error;
 
         P_PHI_0   <= '0';
         Q3_PRAS_N <= '0';
         wait for 1 ns;
-        assert(ENABLE_N = '1') report "When P_PHI_0 and Q3_PRAS_N LOW; expect ENABLE HIGH" severity error;
+        assert(RA_ENABLE_N = '1') report "When P_PHI_0 and Q3_PRAS_N LOW; expect ENABLE HIGH" severity error;
 
         A     <= "XXXXXXX00X000000";
         PRAS_N <= '1';


### PR DESCRIPTION
Finally fixed https://github.com/frozen-signal/Apple_IIe_MMU_IOU/issues/4.

The IOU and MMU MUX component did not have any /RAS hold time.