### PR TITLE
Fixed the video scanner timing problem

### DIFF
--- a/IOU/IOU.vhdl
+++ b/IOU/IOU.vhdl
@@ -107,7 +107,7 @@ architecture RTL of IOU is
         port (
             POC_N   : in std_logic;
             NTSC    : in std_logic;
-            P_PHI_2 : in std_logic;
+            PHI_0   : in std_logic;
 
             HPE_N                  : out std_logic;
             V5, V4, V3, V2, V1, V0 : out std_logic;
@@ -411,7 +411,7 @@ begin
     U_VIDEO_SCANNER : VIDEO_SCANNER port map(
         POC_N   => POC_N,
         NTSC    => NTSC,
-        P_PHI_2 => P_PHI_2,
+        PHI_0   => PHI_0,
         HPE_N   => HPE_N,
         V5      => V5,
         V4      => V4,

--- a/IOU/VIDEO_SCANNER.vhdl
+++ b/IOU/VIDEO_SCANNER.vhdl
@@ -6,7 +6,7 @@ entity VIDEO_SCANNER is
     port (
         POC_N   : in std_logic;
         NTSC    : in std_logic;
-        P_PHI_2 : in std_logic;
+        PHI_0   : in std_logic;
 
         HPE_N                  : out std_logic;
         V5, V4, V3, V2, V1, V0 : out std_logic;
@@ -23,16 +23,15 @@ end VIDEO_SCANNER;
 -- tries to keep close to the emulator schematics, but this is an exception. The implementation below is
 -- more efficient and simpler than 6x LS161s chained with a ripple carry overflow.
 architecture RTL of VIDEO_SCANNER is
-    signal counters : unsigned(23 downto 0); -- It's safe if we don't initialize counters: at power-up POC_N is LOW
-    --    and will initialize the signal.
+    signal counters : unsigned(20 downto 0); -- It's safe if we don't initialize counters: at power-up POC_N is LOW and will initialize the signal.
 
     signal HPE_N_INT, VA_INT, TC_INT : std_logic;
 begin
-    process (P_PHI_2, POC_N)
+    process (PHI_0, POC_N)
     begin
         if (POC_N = '0') then
-            counters <= "111111110000000000000000";
-        elsif (rising_edge(P_PHI_2)) then
+            counters <= "111110000000000000000";
+        elsif (rising_edge(PHI_0)) then
             if (HPE_N_INT = '0') then
                 counters(6 downto 0) <= "1000000";
             else

--- a/MMU/MMU.vhdl
+++ b/MMU/MMU.vhdl
@@ -121,7 +121,7 @@ architecture RTL of MMU is
             C00X_N      : in std_logic;
             R_W_N       : in std_logic;
             RESET_N     : in std_logic;
-            PHI_0       : in std_logic;
+            PHI_1       : in std_logic;
 
             EN80VID   : out std_logic;
             FLG1      : out std_logic;
@@ -428,7 +428,7 @@ begin
         C00X_N      => MC00X_N,
         R_W_N       => R_W_N,
         RESET_N     => MPON_N,
-        PHI_0       => PHI_0,
+        PHI_1       => PHI_1,
 
         EN80VID   => EN80VID,
         FLG1      => FLG1,

--- a/test/IOU/VIDEO_SCANNER_TB.vhdl
+++ b/test/IOU/VIDEO_SCANNER_TB.vhdl
@@ -10,7 +10,7 @@ architecture VIDEO_SCANNER_TEST of VIDEO_SCANNER_TB is
         port (
             POC_N   : in std_logic;
             NTSC    : in std_logic;
-            P_PHI_2 : in std_logic;
+            PHI_0   : in std_logic;
 
             HPE_N                  : out std_logic;
             V5, V4, V3, V2, V1, V0 : out std_logic;
@@ -25,7 +25,7 @@ architecture VIDEO_SCANNER_TEST of VIDEO_SCANNER_TB is
 
     signal POC_N   : std_logic;
     signal NTSC    : std_logic;
-    signal P_PHI_2 : std_logic;
+    signal PHI_0   : std_logic;
 
     signal TC                     : std_logic;
     signal V5, V4, V3, V2, V1, V0 : std_logic;
@@ -40,7 +40,7 @@ begin
     dut : VIDEO_SCANNER port map(
         POC_N   => POC_N,
         NTSC    => NTSC,
-        P_PHI_2 => P_PHI_2,
+        PHI_0   => PHI_0,
         V5      => V5,
         V4      => V4,
         V3      => V3,
@@ -67,7 +67,7 @@ begin
     begin
         -- When POC_N is low, the video scanner should clear its values (asynchronously)
         -- POC_N will be LOW when computer is turned on. This is the only time the video scanner is cleared. ----------
-        P_PHI_2 <= '0';
+        PHI_0   <= '0';
         POC_N   <= '0';
         NTSC    <= '1';
         wait for 1 ns;
@@ -92,7 +92,7 @@ begin
         -- After POC_N goes HIGH, initial values are loaded.
         POC_N <= '1';
         wait for 489.9634322 ns;
-        P_PHI_2 <= '1';
+        PHI_0   <= '1';
         wait for 489.9634322 ns;
         assert(H0 = '0') report "H0 should be LOW" severity error;
         assert(H1 = '0') report "H1 should be LOW" severity error;
@@ -114,9 +114,9 @@ begin
         assert(TC = '0') report "TC should be LOW" severity error;
 
         for i in 1 to 15 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -139,9 +139,9 @@ begin
         assert(V5 = '0') report "V5 should be LOW" severity error;
         assert(TC = '0') report "TC should be LOW" severity error;
 
-        P_PHI_2 <= '0';
+        PHI_0   <= '0';
         wait for 489.9634322 ns;
-        P_PHI_2 <= '1';
+        PHI_0   <= '1';
         wait for 489.9634322 ns;
 
         -- C9 should rollover and D9 increase 1
@@ -164,9 +164,9 @@ begin
         assert(TC = '0') report "TC should be LOW" severity error;
 
         for i in 80 to 191 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -191,9 +191,9 @@ begin
 
         -- 130: 128 steps + 2x loads
         for i in 1 to 130 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -218,9 +218,9 @@ begin
 
         -- 260: 256 steps + 4x loads
         for i in 1 to 260 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -245,9 +245,9 @@ begin
 
         -- 520: 512 steps + 8x loads
         for i in 1 to 520 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -272,9 +272,9 @@ begin
 
         -- 1040: 1024 steps + 16x loads
         for i in 1 to 1040 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -299,9 +299,9 @@ begin
 
         -- 2080: 2048 steps + 32x loads
         for i in 1 to 2080 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -326,9 +326,9 @@ begin
 
         -- 4160: 4096 steps + 64x loads
         for i in 1 to 4160 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -353,9 +353,9 @@ begin
 
         -- 8320: 8192 steps + 128x loads
         for i in 1 to 8320 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -380,9 +380,9 @@ begin
 
         -- 16640: 16384 steps + 256x loads
         for i in 1 to 16640 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -404,9 +404,9 @@ begin
         assert(V4 = '1') report "V4 should be HIGH" severity error;
         assert(V5 = '1') report "V5 should be HIGH" severity error;
         assert(TC = '1') report "TC should be HIGH" severity error;
-        P_PHI_2 <= '0';
+        PHI_0   <= '0';
         wait for 489.9634322 ns;
-        P_PHI_2 <= '1';
+        PHI_0   <= '1';
         wait for 489.9634322 ns;
 
         -- Once the video scanner power-on cycle is completed, a complete video scanner cycle will be 17030 P_PHI_2 cycles (for NTSC).
@@ -430,9 +430,9 @@ begin
         assert(V5 = '0') report "V5 should be LOW" severity error;
 
         for i in 1 to 17029 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
@@ -455,41 +455,41 @@ begin
         assert(TC = '1') report "TC should be HIGH" severity error;
 
         for i in 1 to 17030 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
         assert(PAKST = '0') report "PAKST should be LOW" severity error;
 
-        P_PHI_2 <= '0';
+        PHI_0   <= '0';
         wait for 489.9634322 ns;
-        P_PHI_2 <= '1';
+        PHI_0   <= '1';
         wait for 489.9634322 ns;
 
         assert(PAKST = '1') report "PAKST should be HIGH" severity error;
 
         for i in 1 to 34060 + 68120 + 136240 - 2 loop
-            P_PHI_2 <= '0';
+            PHI_0   <= '0';
             wait for 489.9634322 ns;
-            P_PHI_2 <= '1';
+            PHI_0   <= '1';
             wait for 489.9634322 ns;
         end loop;
 
         assert(TC14S = '0') report "TC14S should be LOW" severity error;
 
-        P_PHI_2 <= '0';
+        PHI_0   <= '0';
         wait for 489.9634322 ns;
-        P_PHI_2 <= '1';
+        PHI_0   <= '1';
         wait for 489.9634322 ns;
 
         assert(TC14S = '1') report "TC14S should be HIGH" severity error;
         assert(FLASH = '0') report "FLASH should be LOW" severity error;
 
-        P_PHI_2 <= '0';
+        PHI_0   <= '0';
         wait for 489.9634322 ns;
-        P_PHI_2 <= '1';
+        PHI_0   <= '1';
         wait for 489.9634322 ns;
 
         assert(FLASH = '1') report "FLASH should be HIGH" severity error;

--- a/test/IOU/test_cases/mocks/VIDEO_SCANNER_SPY.vhdl
+++ b/test/IOU/test_cases/mocks/VIDEO_SCANNER_SPY.vhdl
@@ -6,7 +6,7 @@ entity VIDEO_SCANNER_SPY is
     port (
         POC_N   : in std_logic;
         NTSC    : in std_logic;
-        P_PHI_2 : in std_logic;
+        PHI_0   : in std_logic;
 
         HPE_N                  : out std_logic;
         V5, V4, V3, V2, V1, V0 : out std_logic;
@@ -24,7 +24,7 @@ architecture SPY of VIDEO_SCANNER_SPY is
         port (
             POC_N   : in std_logic;
             NTSC    : in std_logic;
-            P_PHI_2 : in std_logic;
+            PHI_0   : in std_logic;
 
             HPE_N                  : out std_logic;
             V5, V4, V3, V2, V1, V0 : out std_logic;
@@ -45,7 +45,7 @@ begin
     U_VIDEO_SCANNER : VIDEO_SCANNER port map(
         POC_N   => POC_N,
         NTSC    => NTSC,
-        P_PHI_2 => P_PHI_2,
+        PHI_0   => PHI_0,
         HPE_N   => HPE_N_INT,
         V5      => V5_INT,
         V4      => V4_INT,

--- a/test/MMU/test_cases/MMU_TB_MD7.vhdl
+++ b/test/MMU/test_cases/MMU_TB_MD7.vhdl
@@ -111,12 +111,15 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- Set EN80VID
         TEST_STEP <= x"01";
         R_W_N     <= '0';
         A         <= x"C001";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C018";
@@ -129,6 +132,7 @@ begin
         R_W_N     <= '0';
         A         <= x"C000";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C018";
@@ -149,12 +153,15 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- Set FLG1
         TEST_STEP <= x"04";
         R_W_N     <= '0';
         A         <= x"C003";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C013";
@@ -167,6 +174,7 @@ begin
         R_W_N     <= '0';
         A         <= x"C002";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C013";
@@ -176,6 +184,8 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- FLG2 -----------------------------------------------------------
         TEST_STEP <= x"06";
@@ -187,12 +197,16 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
+
 
         -- Set FLG2
         TEST_STEP <= x"07";
         R_W_N     <= '0';
         A         <= x"C005";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C014";
@@ -205,6 +219,7 @@ begin
         R_W_N     <= '0';
         A         <= x"C004";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C014";
@@ -214,6 +229,8 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- PENIO_N ---------------------------------------------------------
         TEST_STEP <= x"09";
@@ -225,12 +242,15 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- Set PENIO_N
         TEST_STEP <= x"0A";
         R_W_N     <= '0';
         A         <= x"C007";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C015";
@@ -243,6 +263,7 @@ begin
         R_W_N     <= '0';
         A         <= x"C006";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C015";
@@ -252,6 +273,8 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- ALTSTKZP -------------------------------------------------------
         TEST_STEP <= x"0C";
@@ -263,12 +286,15 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- Set ALTSTKZP
         TEST_STEP <= x"0D";
         R_W_N     <= '0';
         A         <= x"C009";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C016";
@@ -281,6 +307,7 @@ begin
         R_W_N     <= '0';
         A         <= x"C008";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C016";
@@ -290,6 +317,8 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- INTC300_N ------------------------------------------------------
         TEST_STEP <= x"0F";
@@ -301,12 +330,15 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- Set INTC300_N
         TEST_STEP <= x"10";
         R_W_N     <= '0';
         A         <= x"C00B";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C017";
@@ -319,6 +351,7 @@ begin
         R_W_N     <= '0';
         A         <= x"C00A";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C017";
@@ -328,6 +361,8 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- C05X SOFT SWITCHES -------------------------------------------------------------------------------------
         -- We can't directly probe the C05X soft switches. We can check their value via CASEN_N
@@ -337,14 +372,17 @@ begin
         R_W_N     <= '0';
         A         <= x"C057"; -- SET HIRES
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
         R_W_N <= '0';
         A     <= x"C055"; -- SET PG2
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
         R_W_N <= '0';
         A     <= x"C001"; -- SET EN80VID
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"2000";
@@ -354,20 +392,25 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- HIRES is SET, PG2 is RESET -------------------------------------
         TEST_STEP <= x"13";
         R_W_N     <= '0';
         A         <= x"C057"; -- SET HIRES
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
         R_W_N <= '0';
         A     <= x"C054"; -- RESET PG2
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
         R_W_N <= '0';
         A     <= x"C001"; -- SET EN80VID
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"2000";
@@ -377,20 +420,25 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- HIRES is RESET, PG2 is SET -------------------------------------
         TEST_STEP <= x"14";
         R_W_N     <= '0';
         A         <= x"C056"; -- RESET HIRES
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
         R_W_N <= '0';
         A     <= x"C055"; -- SET PG2
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
         R_W_N <= '0';
         A     <= x"C001"; -- SET EN80VID
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"2000";
@@ -400,6 +448,8 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- C08X SOFT SWITCHES -------------------------------------------------------------------------------------
         -- BANK1/BANK2 ----------------------------------------------------
@@ -412,12 +462,15 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- Set BANK1
         TEST_STEP <= x"16";
         R_W_N     <= '1';
         A         <= x"C088";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C011";
@@ -430,6 +483,7 @@ begin
         R_W_N     <= '1';
         A         <= x"C080";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C011";
@@ -439,6 +493,8 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- RDRAM/RDROM ----------------------------------------------------
         TEST_STEP <= x"18";
@@ -450,12 +506,15 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- Set RDRAM
         TEST_STEP <= x"19";
         R_W_N     <= '1';
         A         <= x"C080";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C012";
@@ -468,6 +527,7 @@ begin
         R_W_N     <= '1';
         A         <= x"C081";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C012";
@@ -477,30 +537,37 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- WRPROT ---------------------------------------------------------
         TEST_STEP <= x"1B";
         R_W_N     <= '0';
         A         <= x"C057"; -- SET HIRES
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
         R_W_N <= '0';
         A     <= x"C054"; -- RESET PG2
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
         R_W_N <= '0';
         A     <= x"C001"; -- SET EN80VID
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C081"; -- To set WRPROT, first read any odd address in C08X range...
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '1';
         A     <= x"C080"; -- ...then read even address in C08X range.
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '0';
         A     <= x"D000";
@@ -513,6 +580,7 @@ begin
         A     <= x"C081";
         wait until rising_edge(PHI_0);
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         R_W_N <= '0';
         A     <= x"D000";
@@ -522,6 +590,8 @@ begin
 
         TEST_STEP <= "UUUUUUUU";
         resetMMU(PHI_0, A);
+        wait until rising_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
 
         -- MD7 ENABLING -------------------------------------------------------------------------------------------
         -- When the MPU reads the state of an MMU soft switch, the MD7 enable gate appears to be PHASE0 + PHASE0' • Q3 • RAS'
@@ -538,6 +608,7 @@ begin
 
         TEST_STEP <= x"1D";
         wait until falling_edge(PHI_0);
+        wait until falling_edge(CLK_14M);
         assert(MD7 = '0') report "expect MD7 LOW (PHI_1 * Q3 * PRAS_N phase)" severity error;
 
         TEST_STEP <= x"1E";


### PR DESCRIPTION
Use PHI_0 instead of P_PHI_2 to have the same timings as the ASIC.