### PR TITLE
Fixed /EN80 falling when it's not supposed to

### DIFF
--- a/MMU/MMU_SELMB.vhdl
+++ b/MMU/MMU_SELMB.vhdl
@@ -3,37 +3,50 @@ use IEEE.std_logic_1164.all;
 
 entity MMU_SELMB is
     port (
-        A15, A14,
-        A13, A10    : in std_logic;
+        S_00_1XX    : in std_logic;  -- HIGH when the ADDRESS at the MMU's input is between $0000 - $01FF ($0[0-1]XX)
+        S_04_7XX    : in std_logic;  -- HIGH when the ADDRESS at the MMU's input is between $0400 - $07FF ($0[4-7]XX)
+        S_2_3XXX    : in std_logic;  -- HIGH when the ADDRESS at the MMU's input is between $2000 - $3FFF ($[2-3]XXX)
+        D_FXXX      : in std_logic;
         HIRES       : in std_logic;
-        PHI_0_7XX   : in std_logic;
         EN80VID     : in std_logic;
         PG2         : in std_logic;
         FLG1        : in std_logic;
         FLG2        : in std_logic;
         R_W_N       : in std_logic;
         ALTSTKZP    : in std_logic;
-        D_FXXX      : in std_logic;
-        PHI_0_1XX_N : in std_logic;
 
         SELMB_N : out std_logic
     );
 end MMU_SELMB;
 
 architecture RTL of MMU_SELMB is
-    signal L2_11, K4_10, K7_6, K7_8, S3_3, S3_8, L3_4 : std_logic;
 begin
-    -- MMU_2 @B-1:L3_13
-    L2_11 <= (((A15 nor A14) and A13 and HIRES) -- L2_6
-        or (A10 and PHI_0_7XX))                 -- B2_6
-        and EN80VID;
+    process (S_00_1XX, S_04_7XX, S_2_3XXX, D_FXXX, EN80VID,
+             HIRES, R_W_N, PG2, ALTSTKZP, FLG1, FLG2)
+    begin
+        if (S_04_7XX = '1' and EN80VID = '1')
+          or (S_2_3XXX = '1' and HIRES = '1' and EN80VID = '1') then
+            -- When accessing primary display range ($0400-$07FF) while EN80VID is set
+            -- or
+            -- When accessing HIRES display range ($2000-$3FFF) while EN80VID and HIRES are set,
+            -- PG2 switches between motherboard RAM (PG2 = '0') and AUX RAM (PG2 = '1')
+            SELMB_N <= PG2;
+        elsif D_FXXX = '1' or S_00_1XX = '1' then
+            -- ALTSTKZP switches the $0000-$01FF and the $D000-$FFFF range between
+            -- motherboard RAM (ALTSTKZP = '0') and AUX RAM (ALTSTKZP = '1')
+            SELMB_N <= ALTSTKZP;
 
-    K7_8  <= (FLG1 and R_W_N) nor ((not R_W_N) and FLG2);
-    K4_10 <= not K7_8;
-    K7_6  <= (K4_10 and (not L2_11)) nor (L2_11 and PG2);
-    S3_3  <= (not D_FXXX) and PHI_0_1XX_N;
-    S3_8  <= S3_3 and K7_6;
-    L3_4  <= (ALTSTKZP nor S3_3);
+        -- Note: It's important that the following two tests are done after the 'address-based' checks above.
+        --       (See "Understanding the Apple IIe" by Jim Sather, p.5-25, paragraph beginning with "RAMRD and RAMWRT...")
+        elsif R_W_N = '1' then
+            -- If it's a read operation, FLG1 (also called RAMRD) switches between
+            -- motherboard RAM (FLG1 = '0') and AUX RAM (FLG1 = '1')
+            SELMB_N <= FLG1;
+        else
+            -- If it's a write operation, FLG2 (also called RAMWRT) switches between
+            -- motherboard RAM (FLG2 = '0') and AUX RAM (FLG2 = '1')
+            SELMB_N <= FLG2;
+        end if;
+    end process;
 
-    SELMB_N <= L3_4 nor S3_8;
 end RTL;

--- a/MMU/MMU_SOFT_SWITCHES_C08X.vhdl
+++ b/MMU/MMU_SOFT_SWITCHES_C08X.vhdl
@@ -37,7 +37,7 @@ begin
 
     -- Contrary to what is drawn in MMU_1 @C-1:E4-9, the CLK signal of the LS175 should be
     -- (inverted DEV0_N): DEV0_N goes LOW when C08X*PHI_0 is accessed. Since the LS175 stores
-    -- D on the rising edge of CLK it's clear that DEV_0 is to be inverted. Confirmed by
+    -- D on the rising edge of CLK it's clear that DEV_0_N is to be inverted. Confirmed by
     -- looking at the DET.T that handles RDROM in the ASIC schematic
     CLK <= not DEV0_N;
 

--- a/test/MMU/MMU_ADDR_DECODER_TB.vhdl
+++ b/test/MMU/MMU_ADDR_DECODER_TB.vhdl
@@ -32,8 +32,9 @@ architecture MMU_ADDR_DECODER_TEST of MMU_ADDR_DECODER_TB is
             MC07X_N : out std_logic;
             MCFFF_N : out std_logic;
 
-            PHI_0_7XX   : out std_logic;
-            PHI_0_1XX_N : out std_logic;
+            S_00_1XX    : out std_logic;
+            S_04_7XX    : out std_logic;
+            S_2_3XXX    : out std_logic;
             S_01XX_N    : out std_logic
         );
     end component;
@@ -41,7 +42,7 @@ architecture MMU_ADDR_DECODER_TEST of MMU_ADDR_DECODER_TB is
     signal A : std_logic_vector(15 downto 0);
     signal PHI_0, CXXX_FXXX, FXXX_N, EXXX_N, DXXX_N, CXXX, C8_FXX, C8_FXX_N, C0_7XX_N,
     E_FXXX_N, D_FXXX, MC0XX_N, MC3XX, MC00X_N, MC01X_N, MC04X_N, MC05X_N, MC06X_N, MC07X_N, MCFFF_N,
-    PHI_0_7XX, PHI_0_1XX_N, S_01XX_N : std_logic;
+    S_00_1XX, S_04_7XX, S_2_3XXX, S_01XX_N : std_logic;
 
 begin
     dut : MMU_ADDR_DECODER port map(
@@ -66,8 +67,9 @@ begin
         MC06X_N     => MC06X_N,
         MC07X_N     => MC07X_N,
         MCFFF_N     => MCFFF_N,
-        PHI_0_7XX   => PHI_0_7XX,
-        PHI_0_1XX_N => PHI_0_1XX_N,
+        S_00_1XX    => S_00_1XX,
+        S_04_7XX    => S_04_7XX,
+        S_2_3XXX    => S_2_3XXX,
         S_01XX_N    => S_01XX_N
     );
 
@@ -95,9 +97,7 @@ begin
         assert(MC06X_N = '1') report "When A is not in CXXX-FXXX range expect MC06X_N HIGH" severity error;
         assert(MC07X_N = '1') report "When A is not in CXXX-FXXX range expect MC07X_N HIGH" severity error;
         assert(MCFFF_N = '1') report "When A is not in CXXX-FXXX range expect MCFFF_N HIGH" severity error;
-        assert(PHI_0_7XX = '0') report "When A is not in 07XX range expect PHI_0_7XX LOW" severity error;
-        assert(PHI_0_1XX_N = '1') report "When A is not in 01XX range expect PHI_0_1XX_N HIGH" severity error;
-        assert(S_01XX_N = '1') report "When A is not in 00XX range expect 01XX_N HIGH" severity error;
+        assert(S_01XX_N = '1') report "When A is not in 01XX range expect 01XX_N HIGH" severity error;
 
         A <= x"F000";
         wait for 1 ns;
@@ -292,17 +292,62 @@ begin
         assert(MC07X_N = '1') report "When A is CFFF expect MC07X_N HIGH" severity error;
         assert(MCFFF_N = '0') report "When A is CFFF expect MCFFF_N LOW" severity error;
 
+
+        A <= x"0000";
+        wait for 1 ns;
+        assert(S_00_1XX = '1') report "When A is in 0000-01FF range expect S_00_1XX HIGH" severity error;
+        assert(S_04_7XX = '0') report "When A is not in 0400-07FF range expect S_04_7XX LOW" severity error;
+        assert(S_2_3XXX = '0') report "When A is not in 2000-3FFF range expect S_2_3XXX LOW" severity error;
+        assert(S_01XX_N = '1') report "When A is not in 01XX range expect S_01XX_N HIGH" severity error;
+
+        A <= x"01FF";
+        wait for 1 ns;
+        assert(S_00_1XX = '1') report "When A is in 0000-01FF range expect S_00_1XX HIGH" severity error;
+        assert(S_04_7XX = '0') report "When A is not in 0400-07FF range expect S_04_7XX LOW" severity error;
+        assert(S_2_3XXX = '0') report "When A is not in 2000-3FFF range expect S_2_3XXX LOW" severity error;
+        assert(S_01XX_N = '0') report "When A is in 01XX range expect S_01XX_N LOW" severity error;
+
+        A <= x"0200";
+        wait for 1 ns;
+        assert(S_00_1XX = '0') report "When A is not in 0000-01FF range expect S_00_1XX LOW" severity error;
+        assert(S_04_7XX = '0') report "When A is not in 0400-07FF range expect S_04_7XX LOW" severity error;
+        assert(S_2_3XXX = '0') report "When A is not in 2000-3FFF range expect S_2_3XXX LOW" severity error;
+        assert(S_01XX_N = '1') report "When A is not in 01XX range expect S_01XX_N HIGH" severity error;
+
+        A <= x"0400";
+        wait for 1 ns;
+        assert(S_00_1XX = '0') report "When A is not in 0000-01FF range expect S_00_1XX LOW" severity error;
+        assert(S_04_7XX = '1') report "When A is in 0400-07FF range expect S_04_7XX HIGH" severity error;
+        assert(S_2_3XXX = '0') report "When A is not in 2000-3FFF range expect S_2_3XXX LOW" severity error;
+        assert(S_01XX_N = '1') report "When A is not in 01XX range expect S_01XX_N HIGH" severity error;
+
         A <= x"07FF";
         wait for 1 ns;
-        assert(PHI_0_7XX = '1') report "When A is in 07XX range expect PHI_0_7XX HIGH" severity error;
+        assert(S_00_1XX = '0') report "When A is not in 0000-01FF range expect S_00_1XX LOW" severity error;
+        assert(S_04_7XX = '1') report "When A is in 0400-07FF range expect S_04_7XX HIGH" severity error;
+        assert(S_2_3XXX = '0') report "When A is not in 2000-3FFF range expect S_2_3XXX LOW" severity error;
+        assert(S_01XX_N = '1') report "When A is not in 01XX range expect S_01XX_N HIGH" severity error;
 
-        A <= x"01FF";
+        A <= x"2000";
         wait for 1 ns;
-        assert(PHI_0_1XX_N = '0') report "When A is in 01XX range expect PHI_0_1XX_N LOW" severity error;
+        assert(S_00_1XX = '0') report "When A is not in 0000-01FF range expect S_00_1XX LOW" severity error;
+        assert(S_04_7XX = '0') report "When A is not in 0400-07FF range expect S_04_7XX LOW" severity error;
+        assert(S_2_3XXX = '1') report "When A is in 2000-3FFF range expect S_2_3XXX HIGH" severity error;
+        assert(S_01XX_N = '1') report "When A is not in 01XX range expect S_01XX_N HIGH" severity error;
 
-        A <= x"01FF";
+        A <= x"3FFF";
         wait for 1 ns;
-        assert(S_01XX_N = '0') report "When A is in 00XX range expect S_01XX_N LOW" severity error;
+        assert(S_00_1XX = '0') report "When A is not in 0000-01FF range expect S_00_1XX LOW" severity error;
+        assert(S_04_7XX = '0') report "When A is not in 0400-07FF range expect S_04_7XX LOW" severity error;
+        assert(S_2_3XXX = '1') report "When A is in 2000-3FFF range expect S_2_3XXX HIGH" severity error;
+        assert(S_01XX_N = '1') report "When A is not in 01XX range expect S_01XX_N HIGH" severity error;
+
+        A <= x"4FFF";
+        wait for 1 ns;
+        assert(S_00_1XX = '0') report "When A is not in 0000-01FF range expect S_00_1XX LOW" severity error;
+        assert(S_04_7XX = '0') report "When A is not in 0400-07FF range expect S_04_7XX LOW" severity error;
+        assert(S_2_3XXX = '0') report "When A is not in 2000-3FFF range expect S_2_3XXX LOW" severity error;
+        assert(S_01XX_N = '1') report "When A is not in 01XX range expect S_01XX_N HIGH" severity error;
 
         assert false report "Test done." severity note;
         wait;

--- a/test/MMU/MMU_SELMB_TB.vhdl
+++ b/test/MMU/MMU_SELMB_TB.vhdl
@@ -7,115 +7,113 @@ end MMU_SELMB_TB;
 architecture MMU_SELMB_TEST of MMU_SELMB_TB is
     component MMU_SELMB is
         port (
-            A15, A14,
-            A13, A10    : in std_logic;
+            S_00_1XX    : in std_logic;  -- HIGH when the ADDRESS at the MMU's input is between $0000 - $01FF ($0[0-1]XX)
+            S_04_7XX    : in std_logic;  -- HIGH when the ADDRESS at the MMU's input is between $0400 - $07FF ($0[4-7]XX)
+            S_2_3XXX    : in std_logic;  -- HIGH when the ADDRESS at the MMU's input is between $2000 - $3FFF ($[2-3]XXX)
+            D_FXXX      : in std_logic;
             HIRES       : in std_logic;
-            PHI_0_7XX   : in std_logic;
             EN80VID     : in std_logic;
             PG2         : in std_logic;
             FLG1        : in std_logic;
             FLG2        : in std_logic;
             R_W_N       : in std_logic;
             ALTSTKZP    : in std_logic;
-            D_FXXX      : in std_logic;
-            PHI_0_1XX_N : in std_logic;
 
             SELMB_N : out std_logic
         );
     end component;
 
-    signal A15, A14, A13, A10 : std_logic;
-    signal HIRES              : std_logic;
-    signal PHI_0_7XX          : std_logic;
-    signal EN80VID            : std_logic;
-    signal PG2                : std_logic;
-    signal FLG1               : std_logic;
-    signal FLG2               : std_logic;
-    signal R_W_N              : std_logic;
-    signal ALTSTKZP           : std_logic;
-    signal D_FXXX             : std_logic;
-    signal PHI_0_1XX_N        : std_logic;
-    signal SELMB_N            : std_logic;
+    signal S_00_1XX : std_logic;
+    signal S_04_7XX : std_logic;
+    signal S_2_3XXX : std_logic;
+    signal D_FXXX : std_logic;
+    signal HIRES : std_logic;
+    signal EN80VID : std_logic;
+    signal PG2 : std_logic;
+    signal FLG1 : std_logic;
+    signal FLG2 : std_logic;
+    signal R_W_N : std_logic;
+    signal ALTSTKZP : std_logic;
+    signal SELMB_N : std_logic;
 
 begin
     dut : MMU_SELMB port map(
-        A15         => A15,
-        A14         => A14,
-        A13         => A13,
-        A10         => A10,
-        HIRES       => HIRES,
-        PHI_0_7XX   => PHI_0_7XX,
-        EN80VID     => EN80VID,
-        PG2         => PG2,
-        FLG1        => FLG1,
-        FLG2        => FLG2,
-        R_W_N       => R_W_N,
-        ALTSTKZP    => ALTSTKZP,
-        D_FXXX      => D_FXXX,
-        PHI_0_1XX_N => PHI_0_1XX_N,
-        SELMB_N     => SELMB_N
+        S_00_1XX => S_00_1XX,
+        S_04_7XX => S_04_7XX,
+        S_2_3XXX => S_2_3XXX,
+        D_FXXX => D_FXXX,
+        HIRES => HIRES,
+        EN80VID => EN80VID,
+        PG2 => PG2,
+        FLG1 => FLG1,
+        FLG2 => FLG2,
+        R_W_N => R_W_N,
+        ALTSTKZP => ALTSTKZP,
+        SELMB_N => SELMB_N
     );
 
     process begin
-        A15         <= '0';
-        A14         <= '0';
-        A13         <= '0';
-        A10         <= '0';
-        HIRES       <= '0';
-        PHI_0_7XX   <= '0';
-        EN80VID     <= '0';
-        PG2         <= '0';
-        FLG1        <= '0';
-        FLG2        <= '0';
-        R_W_N       <= '0';
-        ALTSTKZP    <= '0';
-        D_FXXX      <= '0';
-        PHI_0_1XX_N <= '0';
-        wait for 1 ns;
-        assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
+        -- FIXME: Re-write the testbench
 
-        ALTSTKZP <= '1';
-        wait for 1 ns;
-        assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
+        -- A15         <= '0';
+        -- A14         <= '0';
+        -- A13         <= '0';
+        -- A10         <= '0';
+        -- HIRES       <= '0';
+        -- PHI_0_7XX   <= '0';
+        -- EN80VID     <= '0';
+        -- PG2         <= '0';
+        -- FLG1        <= '0';
+        -- FLG2        <= '0';
+        -- R_W_N       <= '0';
+        -- ALTSTKZP    <= '0';
+        -- D_FXXX      <= '0';
+        -- PHI_0_1XX_N <= '0';
+        -- wait for 1 ns;
+        -- assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
 
-        ALTSTKZP    <= '0';
-        PHI_0_1XX_N <= '1';
-        wait for 1 ns;
-        assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
+        -- ALTSTKZP <= '1';
+        -- wait for 1 ns;
+        -- assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
 
-        FLG2 <= '1';
-        wait for 1 ns;
-        assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
+        -- ALTSTKZP    <= '0';
+        -- PHI_0_1XX_N <= '1';
+        -- wait for 1 ns;
+        -- assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
 
-        FLG1  <= '1';
-        FLG2  <= '0';
-        R_W_N <= '1';
-        wait for 1 ns;
-        assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
+        -- FLG2 <= '1';
+        -- wait for 1 ns;
+        -- assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
 
-        FLG1      <= '0';
-        FLG2      <= '0';
-        R_W_N     <= '0';
-        A10       <= '1';
-        PHI_0_7XX <= '1';
-        wait for 1 ns;
-        assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
+        -- FLG1  <= '1';
+        -- FLG2  <= '0';
+        -- R_W_N <= '1';
+        -- wait for 1 ns;
+        -- assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
 
-        EN80VID <= '1';
-        PG2     <= '1';
-        wait for 1 ns;
-        assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
+        -- FLG1      <= '0';
+        -- FLG2      <= '0';
+        -- R_W_N     <= '0';
+        -- A10       <= '1';
+        -- PHI_0_7XX <= '1';
+        -- wait for 1 ns;
+        -- assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
 
-        A10       <= '0';
-        PHI_0_7XX <= '0';
-        A15       <= '0';
-        A13       <= '1';
-        wait for 1 ns;
-        assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
+        -- EN80VID <= '1';
+        -- PG2     <= '1';
+        -- wait for 1 ns;
+        -- assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
 
-        HIRES <= '1';
-        wait for 1 ns;
-        assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
+        -- A10       <= '0';
+        -- PHI_0_7XX <= '0';
+        -- A15       <= '0';
+        -- A13       <= '1';
+        -- wait for 1 ns;
+        -- assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
+
+        -- HIRES <= '1';
+        -- wait for 1 ns;
+        -- assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
 
         assert false report "Test done." severity note;
         wait;

--- a/test/MMU/MMU_SELMB_TB.vhdl
+++ b/test/MMU/MMU_SELMB_TB.vhdl
@@ -53,67 +53,122 @@ begin
     );
 
     process begin
-        -- FIXME: Re-write the testbench
 
-        -- A15         <= '0';
-        -- A14         <= '0';
-        -- A13         <= '0';
-        -- A10         <= '0';
-        -- HIRES       <= '0';
-        -- PHI_0_7XX   <= '0';
-        -- EN80VID     <= '0';
-        -- PG2         <= '0';
-        -- FLG1        <= '0';
-        -- FLG2        <= '0';
-        -- R_W_N       <= '0';
-        -- ALTSTKZP    <= '0';
-        -- D_FXXX      <= '0';
-        -- PHI_0_1XX_N <= '0';
-        -- wait for 1 ns;
-        -- assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
+        -- When accessing primary display range ($0400-$07FF) while EN80VID is set, the state of PG2 is set to SELMB_N
+        EN80VID  <= '1';
+        S_04_7XX <= '1';
+        PG2 <= '0';
+        wait for 1 ns;
+        assert(SELMB_N = '0') report "Expected SELMB_N to be LOW" severity error;
 
-        -- ALTSTKZP <= '1';
-        -- wait for 1 ns;
-        -- assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
+        PG2 <= '1';
+        wait for 1 ns;
+        assert(SELMB_N = '1') report "Expected SELMB_N to be HIGH" severity error;
 
-        -- ALTSTKZP    <= '0';
-        -- PHI_0_1XX_N <= '1';
-        -- wait for 1 ns;
-        -- assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
+        EN80VID  <= '0';
+        R_W_N    <= '0';
+        FLG2     <= 'X';
+        wait for 1 ns;
+        assert(SELMB_N = 'X') report "This address range should be ignored when EN80VID is reset" severity error;
 
-        -- FLG2 <= '1';
-        -- wait for 1 ns;
-        -- assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
 
-        -- FLG1  <= '1';
-        -- FLG2  <= '0';
-        -- R_W_N <= '1';
-        -- wait for 1 ns;
-        -- assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
+        FLG2     <= 'U';
+        R_W_N    <= 'U';
+        S_04_7XX <= '0';
+        wait for 1 ns;
 
-        -- FLG1      <= '0';
-        -- FLG2      <= '0';
-        -- R_W_N     <= '0';
-        -- A10       <= '1';
-        -- PHI_0_7XX <= '1';
-        -- wait for 1 ns;
-        -- assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
 
-        -- EN80VID <= '1';
-        -- PG2     <= '1';
-        -- wait for 1 ns;
-        -- assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
+        -- When accessing HIRES display range ($2000-$3FFF) while EN80VID and HIRES are set, the state of PG2 is set to SELMB_N
+        EN80VID  <= '1';
+        HIRES    <= '1';
+        S_2_3XXX <= '1';
+        PG2 <= '0';
+        wait for 1 ns;
+        assert(SELMB_N = '0') report "Expected SELMB_N to be LOW" severity error;
 
-        -- A10       <= '0';
-        -- PHI_0_7XX <= '0';
-        -- A15       <= '0';
-        -- A13       <= '1';
-        -- wait for 1 ns;
-        -- assert(SELMB_N = '0') report "expect SELMB_N LOW" severity error;
+        PG2 <= '1';
+        wait for 1 ns;
+        assert(SELMB_N = '1') report "Expected SELMB_N to be HIGH" severity error;
 
-        -- HIRES <= '1';
-        -- wait for 1 ns;
-        -- assert(SELMB_N = '1') report "expect SELMB_N HIGH" severity error;
+        EN80VID  <= '0';
+        R_W_N    <= '0';
+        FLG2     <= 'X';
+        wait for 1 ns;
+        assert(SELMB_N = 'X') report "This address range should be ignored when EN80VID is reset" severity error;
+
+        EN80VID  <= '1';
+        HIRES    <= '0';
+        R_W_N    <= '0';
+        FLG2     <= 'X';
+        wait for 1 ns;
+        assert(SELMB_N = 'X') report "This address range should be ignored when HIRES is reset" severity error;
+
+
+        S_2_3XXX <= '0';
+        EN80VID  <= 'U';
+        HIRES    <= 'U';
+        R_W_N    <= 'U';
+        FLG2     <= 'X';
+        PG2 <= 'U';
+        wait for 1 ns;
+
+
+        -- When accessing the $0000-$01FF memory range, the state of ALTSTKZP is set to SELMB_N
+        S_00_1XX <= '1';
+        ALTSTKZP <= '0';
+        wait for 1 ns;
+        assert(SELMB_N = '0') report "Expected SELMB_N to be LOW" severity error;
+
+        ALTSTKZP <= '1';
+        wait for 1 ns;
+        assert(SELMB_N = '1') report "Expected SELMB_N to be HIGH" severity error;
+
+
+        S_00_1XX <= '0';
+        ALTSTKZP <= 'U';
+        wait for 1 ns;
+
+
+        -- When accessing the $D000-$FFFF memory range, the state of ALTSTKZP is set to SELMB_N
+        D_FXXX <= '1';
+        ALTSTKZP <= '0';
+        wait for 1 ns;
+        assert(SELMB_N = '0') report "Expected SELMB_N to be LOW" severity error;
+
+        ALTSTKZP <= '1';
+        wait for 1 ns;
+        assert(SELMB_N = '1') report "Expected SELMB_N to be HIGH" severity error;
+
+
+        D_FXXX <= '0';
+        ALTSTKZP <= 'U';
+        wait for 1 ns;
+
+        -- If it's a read operation, the state of FLG1 is set to SELMB_N
+        R_W_N    <= '1';
+        FLG1     <= '0';
+        wait for 1 ns;
+        assert(SELMB_N = '0') report "Expected SELMB_N to be LOW" severity error;
+
+        FLG1     <= '1';
+        wait for 1 ns;
+        assert(SELMB_N = '1') report "Expected SELMB_N to be HIGH" severity error;
+
+
+        FLG1     <= 'U';
+
+
+        -- In any other cases, the state of FLG2 is set to SELMB_N
+        R_W_N    <= '0';
+        FLG2     <= '0';
+        wait for 1 ns;
+        assert(SELMB_N = '0') report "Expected SELMB_N to be LOW" severity error;
+
+        FLG2     <= '1';
+        wait for 1 ns;
+        assert(SELMB_N = '1') report "Expected SELMB_N to be HIGH" severity error;
+
+
 
         assert false report "Test done." severity note;
         wait;


### PR DESCRIPTION
See issue https://github.com/frozen-signal/Apple_IIe_MMU_IOU/issues/41

Re-wrote SELMB_N and tests
Added enabling to MC05X_N: forced HIGH during PHI_1