### PR TITLE
Fixed glitch with RA_ENABLE_N

### DIFF
--- a/COMMON/RA_MUX.vhdl
+++ b/COMMON/RA_MUX.vhdl
@@ -4,8 +4,9 @@ use IEEE.std_logic_1164.all;
 entity RA_MUX is
     port (
         PHI     : in std_logic;  -- Should be PHI_0 in the case of the MMU, and PHI_1 in the case of the IOU
-        RAS_N   : in std_logic;  -- The delayed PRAS_N signal. See comment below.
+        PRAS_N  : in std_logic;
         Q3      : in std_logic;
+
         ROW_RA0, ROW_RA1, ROW_RA2, ROW_RA3,
         ROW_RA4, ROW_RA5, ROW_RA6, ROW_RA7 : in std_logic;
         COL_RA0, COL_RA1, COL_RA2, COL_RA3,
@@ -18,18 +19,51 @@ entity RA_MUX is
 end RA_MUX;
 
 architecture RTL of RA_MUX is
+    -- We must add the hold times required by the RAM used by the Apple II series. See https://github.com/frozen-signal/Apple_IIe_MMU_IOU/tree/master/CUSTOM/DRAM_HOLD_TIME
+    component DRAM_HOLD_TIME is
+        port (
+            PRAS_N : in std_logic;
+            Q3     : in std_logic;
+
+            D_RAS_N : out std_logic;
+            D_Q3    : out std_logic
+        );
+    end component;
+
+    signal D_RAS_N, D_Q3  : std_logic;  -- Delayed version of the signals
+    signal COMBINED_RAS_N : std_logic;  -- A RAS_N signal that falls with PRAS_N, but rises with the delayed D_RAS_N
 begin
-    RA_ENABLE_N <= not ((Q3 and PHI) or ((not PHI) and (not Q3) and RAS_N));
+    U_DRAM_HOLD_TIME : DRAM_HOLD_TIME port map(
+        PRAS_N  => PRAS_N,
+        Q3      => Q3,
+        D_RAS_N => D_RAS_N,
+        D_Q3    => D_Q3
+    );
+
+    -- The RA bus is driven from the rising edge of RAS_N in the previous phase to the falling edge of Q3 in the current phase.
+    -- Note: A process is used because PHI and Q3 changes at the same time, and Q3 has a slow rise time. The previous implementation:
+    -- RA_ENABLE_N <= not ((Q3 and PHI) or ((not PHI) and (not Q3) and RAS_N));
+    -- caused an issue with the hold time in DRAM_HOLD_TIME. See https://github.com/frozen-signal/Apple_IIe_MMU_IOU/issues/47
+    -- So, the code below shield from the slow-rising Q3 and adds the hold time after the falling_edge of Q3.
+    process (PHI, PRAS_N, Q3, D_Q3)
+    begin
+        if (PHI = '0' and Q3 = '0' and PRAS_N = '1') then
+            RA_ENABLE_N <= '0';
+        elsif (PHI = '1' and falling_edge(D_Q3)) then
+            RA_ENABLE_N <= '1';
+        end if;
+    end process;
 
     -- The Apple IIe RAM reads ROW address on the falling edge of PRAS_N and requires to hold that address for
-    -- a certain delay (~60ns). So we set the ROW before the falling edge of PRAS_N and hold it for as long as RAS_N is HIGH.
-    RA0 <= ROW_RA0 when RAS_N = '1' else COL_RA0;
-    RA1 <= ROW_RA1 when RAS_N = '1' else COL_RA1;
-    RA2 <= ROW_RA2 when RAS_N = '1' else COL_RA2;
-    RA3 <= ROW_RA3 when RAS_N = '1' else COL_RA3;
-    RA4 <= ROW_RA4 when RAS_N = '1' else COL_RA4;
-    RA5 <= ROW_RA5 when RAS_N = '1' else COL_RA5;
-    RA6 <= ROW_RA6 when RAS_N = '1' else COL_RA6;
-    RA7 <= ROW_RA7 when RAS_N = '1' else COL_RA7;
+    -- a certain hold time. So we set the ROW before the falling edge of PRAS_N and hold it for as long as RAS_N is HIGH.
+    COMBINED_RAS_N <= D_RAS_N or PRAS_N;
+    RA0 <= ROW_RA0 when COMBINED_RAS_N = '1' else COL_RA0;
+    RA1 <= ROW_RA1 when COMBINED_RAS_N = '1' else COL_RA1;
+    RA2 <= ROW_RA2 when COMBINED_RAS_N = '1' else COL_RA2;
+    RA3 <= ROW_RA3 when COMBINED_RAS_N = '1' else COL_RA3;
+    RA4 <= ROW_RA4 when COMBINED_RAS_N = '1' else COL_RA4;
+    RA5 <= ROW_RA5 when COMBINED_RAS_N = '1' else COL_RA5;
+    RA6 <= ROW_RA6 when COMBINED_RAS_N = '1' else COL_RA6;
+    RA7 <= ROW_RA7 when COMBINED_RAS_N = '1' else COL_RA7;
 
 end RTL;

--- a/COMMON/RA_MUX.vhdl
+++ b/COMMON/RA_MUX.vhdl
@@ -19,7 +19,8 @@ entity RA_MUX is
 end RA_MUX;
 
 architecture RTL of RA_MUX is
-    -- We must add the hold times required by the RAM used by the Apple II series. See https://github.com/frozen-signal/Apple_IIe_MMU_IOU/tree/master/CUSTOM/DRAM_HOLD_TIME
+    -- This is used to add the hold times required by the RAM used by the Apple II series.
+    -- See https://github.com/frozen-signal/Apple_IIe_MMU_IOU/tree/master/CUSTOM/DRAM_HOLD_TIME
     component DRAM_HOLD_TIME is
         port (
             PRAS_N : in std_logic;

--- a/CUSTOM/DRAM_HOLD_TIME/NOP/DRAM_HOLD_TIME.vhdl
+++ b/CUSTOM/DRAM_HOLD_TIME/NOP/DRAM_HOLD_TIME.vhdl
@@ -7,13 +7,13 @@ entity DRAM_HOLD_TIME is
         PRAS_N : in std_logic;
         Q3     : in std_logic;
 
-        RAS_N      : out std_logic;
-        DELAYED_Q3 : out std_logic
+        D_RAS_N : out std_logic;
+        D_Q3    : out std_logic
     );
 end DRAM_HOLD_TIME;
 
 architecture RTL of DRAM_HOLD_TIME is
 begin
-    RAS_N      <= PRAS_N;
-    DELAYED_Q3 <= Q3;
+    D_RAS_N <= PRAS_N;
+    D_Q3 <= Q3;
 end RTL;

--- a/CUSTOM/DRAM_HOLD_TIME/VENDOR/ALTERA/DRAM_HOLD_TIME.vhdl
+++ b/CUSTOM/DRAM_HOLD_TIME/VENDOR/ALTERA/DRAM_HOLD_TIME.vhdl
@@ -8,14 +8,14 @@ entity DRAM_HOLD_TIME is
         PRAS_N : in std_logic;
         Q3     : in std_logic;
 
-        RAS_N      : out std_logic;
-        DELAYED_Q3 : out std_logic
+        D_RAS_N : out std_logic;
+        D_Q3    : out std_logic
     );
 end DRAM_HOLD_TIME;
 
 architecture RTL of DRAM_HOLD_TIME is
     constant NUM_LCELLS_RAS : positive := 14;
-    constant NUM_LCELLS_Q3 : positive := 10;
+    constant NUM_LCELLS_Q3  : positive := 10;
 
     component LCELL
         port (
@@ -24,8 +24,8 @@ architecture RTL of DRAM_HOLD_TIME is
         );
     end component;
 
-    signal PRAS_N_DELAY : std_logic_vector((NUM_LCELLS_RAS-1) downto 0);
-    signal Q3_DELAY : std_logic_vector((NUM_LCELLS_Q3-1) downto 0);
+    signal PRAS_N_DELAY     : std_logic_vector((NUM_LCELLS_RAS-1) downto 0);
+    signal DELAYED_Q3_DELAY : std_logic_vector(NUM_LCELLS_Q3-1 downto 0);
 begin
     -- PRAS_N DELAY -------------------
     INITIAL_RAS_DELAY : LCELL port map(
@@ -40,20 +40,20 @@ begin
         );
     end generate g_GENERATE_RAS_DELAY;
 
-    RAS_N <= PRAS_N_DELAY(NUM_LCELLS_RAS-1);
+    D_RAS_N <= PRAS_N_DELAY(NUM_LCELLS_RAS-1);
 
     -- Q3 DELAY -----------------------
     INITIAL_Q3_DELAY : LCELL port map(
         A_IN => Q3,
-        A_OUT => Q3_DELAY(0)
+        A_OUT => DELAYED_Q3_DELAY(0)
     );
 
-    g_GENERATE_Q3_DELAY: for i in 0 to (NUM_LCELLS_Q3-2) generate
+    g_GENERATE_Q3: for i in 0 to (NUM_LCELLS_Q3-2) generate
         DELAY : LCELL port map(
-            A_IN => Q3_DELAY(i),
-            A_OUT => Q3_DELAY(i+1)
+            A_IN => DELAYED_Q3_DELAY(i),
+            A_OUT => DELAYED_Q3_DELAY(i+1)
         );
-    end generate g_GENERATE_Q3_DELAY;
+    end generate g_GENERATE_Q3;
 
-    DELAYED_Q3 <= Q3_DELAY(NUM_LCELLS_Q3-1);
+    D_Q3 <= DELAYED_Q3_DELAY(NUM_LCELLS_Q3-1);
 end RTL;

--- a/CUSTOM/MMU_HOLD_TIME/NOP/MMU_HOLD_TIME.vhdl
+++ b/CUSTOM/MMU_HOLD_TIME/NOP/MMU_HOLD_TIME.vhdl
@@ -6,11 +6,11 @@ entity MMU_HOLD_TIME is
     port (
         PHI_0 : in std_logic;
 
-        DELAYED_PHI_0 : out std_logic
+        D_PHI_0 : out std_logic
     );
 end MMU_HOLD_TIME;
 
 architecture RTL of MMU_HOLD_TIME is
 begin
-    DELAYED_PHI_0 <= PHI_0;
+    D_PHI_0 <= PHI_0;
 end RTL;

--- a/CUSTOM/MMU_HOLD_TIME/VENDOR/ALTERA/MMU_HOLD_TIME.vhdl
+++ b/CUSTOM/MMU_HOLD_TIME/VENDOR/ALTERA/MMU_HOLD_TIME.vhdl
@@ -7,7 +7,7 @@ entity MMU_HOLD_TIME is
     port (
         PHI_0 : in std_logic;
 
-        DELAYED_PHI_0 : out std_logic
+        D_PHI_0 : out std_logic
     );
 end MMU_HOLD_TIME;
 
@@ -35,5 +35,5 @@ begin
         );
     end generate g_GENERATE_DELAY;
 
-    DELAYED_PHI_0 <= PHI_0_DELAY(NUM_LCELLS-1);
+    D_PHI_0 <= PHI_0_DELAY(NUM_LCELLS-1);
 end RTL;

--- a/IOU/IOU.vhdl
+++ b/IOU/IOU.vhdl
@@ -42,16 +42,6 @@ end IOU;
 architecture RTL of IOU is
     constant NTSC : std_logic := NTSC_CONSTANT;
 
-    component DRAM_HOLD_TIME is
-        port (
-            PRAS_N : in std_logic;
-            Q3     : in std_logic;
-
-            RAS_N      : out std_logic;
-            DELAYED_Q3 : out std_logic
-        );
-    end component;
-
     component POWER_ON_DETECTION is
         port (
             PHI_0 : in std_logic;
@@ -249,12 +239,12 @@ architecture RTL of IOU is
     component VIDEO_ADDR_MUX is
         port (
             PHI_1          : in std_logic;
+            PRAS_N         : in std_logic;
             Q3             : in std_logic;
             PG2_N          : in std_logic;
             EN80VID        : in std_logic;
             HIRESEN_N      : in std_logic;
             VA, VB, VC     : in std_logic;
-            RAS_N          : in std_logic;
             V0, V1, V2     : in std_logic;
             H0, H1, H2     : in std_logic;
             E0, E1, E2, E3 : in std_logic;
@@ -337,7 +327,6 @@ architecture RTL of IOU is
         );
     end component;
 
-    signal RAS_N, DELAYED_Q3                                                                      : std_logic;
     signal RC01X_N, P_PHI_0, P_PHI_1, Q3_PRAS_N                                                   : std_logic;
     signal P_PHI_2, PHI_1, CTC14S                                                                 : std_logic;
     signal FORCE_RESET_N_LOW                                                                      : std_logic;
@@ -358,13 +347,6 @@ architecture RTL of IOU is
 
     signal H0_INT, LGR_TXT_N_INT, ORA7_INT : std_logic;
 begin
-    U_DRAM_HOLD_TIME : DRAM_HOLD_TIME port map(
-        PRAS_N     => PRAS_N,
-        Q3         => Q3,
-        RAS_N      => RAS_N,
-        DELAYED_Q3 => DELAYED_Q3
-    );
-
     U_POWER_ON_DETECTION : POWER_ON_DETECTION port map(
         PHI_0 => PHI_0,
         POC_N => POC_N
@@ -584,14 +566,14 @@ begin
     PG2_N <= not PG2;
     U_VIDEO_ADDR_MUX : VIDEO_ADDR_MUX port map(
         PHI_1       => PHI_1,
-        Q3          => DELAYED_Q3,
+        PRAS_N      => PRAS_N,
+        Q3          => Q3,
         PG2_N       => PG2_N,
         EN80VID     => EN80VID,
         HIRESEN_N   => HIRESEN_N,
         VA          => VA,
         VB          => VB,
         VC          => VC,
-        RAS_N       => RAS_N,
         V0          => V0,
         V1          => V1,
         V2          => V2,

--- a/IOU/VIDEO_ADDR_MUX.vhdl
+++ b/IOU/VIDEO_ADDR_MUX.vhdl
@@ -4,12 +4,12 @@ use IEEE.std_logic_1164.all;
 entity VIDEO_ADDR_MUX is
     port (
         PHI_1          : in std_logic;
+        PRAS_N         : in std_logic;
         Q3             : in std_logic;
         PG2_N          : in std_logic;
         EN80VID        : in std_logic;
         HIRESEN_N      : in std_logic;
         VA, VB, VC     : in std_logic;
-        RAS_N          : in std_logic;
         V0, V1, V2     : in std_logic;
         H0, H1, H2     : in std_logic;
         E0, E1, E2, E3 : in std_logic;
@@ -24,7 +24,7 @@ architecture RTL of VIDEO_ADDR_MUX is
     component RA_MUX is
         port (
             PHI     : in std_logic;
-            RAS_N   : in std_logic;
+            PRAS_N  : in std_logic;
             Q3      : in std_logic;
             ROW_RA0, ROW_RA1, ROW_RA2, ROW_RA3,
             ROW_RA4, ROW_RA5, ROW_RA6, ROW_RA7 : in std_logic;
@@ -49,9 +49,9 @@ begin
     ZE    <= HIRESEN_N nor VID_PG2_N; -- IOU_2 @A-4:L9-4
 
     IOU_RA_MUX : RA_MUX port map(
-        PHI   => PHI_1,
-        RAS_N => RAS_N,
-        Q3    => Q3,
+        PHI    => PHI_1,
+        PRAS_N => PRAS_N,
+        Q3     => Q3,
 
         -- IOU_1 @C-D-3:A9 & B9
         ROW_RA0 => H0,

--- a/MMU/MMU.vhdl
+++ b/MMU/MMU.vhdl
@@ -25,21 +25,11 @@ entity MMU is
 end MMU;
 
 architecture RTL of MMU is
-    component DRAM_HOLD_TIME is
-        port (
-            PRAS_N : in std_logic;
-            Q3     : in std_logic;
-
-            RAS_N      : out std_logic;
-            DELAYED_Q3 : out std_logic
-        );
-    end component;
-
     component MMU_HOLD_TIME is
         port (
             PHI_0 : in std_logic;
 
-            DELAYED_PHI_0 : out std_logic
+            D_PHI_0 : out std_logic
         );
     end component;
 
@@ -254,16 +244,16 @@ architecture RTL of MMU is
 
     component MMU_ROMEN is
         port (
-            DELAYED_PHI_0 : in std_logic;
-            INTC8ACC      : in std_logic;
-            INTC3ACC_N    : in std_logic;
-            CXXX          : in std_logic;
-            DXXX_N        : in std_logic;
-            E_FXXX_N      : in std_logic;
-            INH           : in std_logic;
-            RDROM         : in std_logic;
-            CENROM1       : in std_logic;
-            R_W_N         : in std_logic;
+            D_PHI_0    : in std_logic;
+            INTC8ACC   : in std_logic;
+            INTC3ACC_N : in std_logic;
+            CXXX       : in std_logic;
+            DXXX_N     : in std_logic;
+            E_FXXX_N   : in std_logic;
+            INH        : in std_logic;
+            RDROM      : in std_logic;
+            CENROM1    : in std_logic;
+            R_W_N      : in std_logic;
 
             ROMEN2_N : out std_logic;
             ROMEN1_N : out std_logic
@@ -314,19 +304,19 @@ architecture RTL of MMU is
 
     component MMU_RA is
         port (
-            A      : in std_logic_vector(15 downto 0);
-            RAS_N  : in std_logic;
-            PHI_0  : in std_logic;
-            Q3     : in std_logic;
-            DXXX_N : in std_logic;
-            BANK1  : in std_logic;
+            A       : in std_logic_vector(15 downto 0);
+            PHI_0   : in std_logic;
+            PRAS_N  : in std_logic;
+            Q3      : in std_logic;
+            DXXX_N  : in std_logic;
+            BANK1   : in std_logic;
 
             RA          : out std_logic_vector(7 downto 0);
             RA_ENABLE_N : out std_logic
         );
     end component;
 
-    signal DELAYED_PHI_0, DELAYED_Q3, RAS_N                                                      : std_logic;
+    signal D_PHI_0 : std_logic;  -- Delayed PHI_0
     signal PHI_1, INH                                                                            : std_logic;
     signal CXXX_FXXX, FXXX_N, EXXX_N, DXXX_N, CXXX, C8_FXX, C8_FXX_N, C0_7XX_N, E_FXXX_N, D_FXXX : std_logic;
     signal MC0XX_N, MC3XX, MC00X_N, MC01X_N, MC04X_N, MC05X_N, MC06X_N, MC07X_N, MCFFF_N         : std_logic;
@@ -351,16 +341,9 @@ begin
     PHI_1 <= not PHI_0;
     INH   <= not INH_N;
 
-    U_DRAM_HOLD_TIME : DRAM_HOLD_TIME port map(
-        PRAS_N     => PRAS_N,
-        Q3         => Q3,
-        RAS_N      => RAS_N,
-        DELAYED_Q3 => DELAYED_Q3
-    );
-
     U_MMU_HOLD_TIME : MMU_HOLD_TIME port map(
-        PHI_0 => PHI_0,
-        DELAYED_PHI_0 => DELAYED_PHI_0
+        PHI_0   => PHI_0,
+        D_PHI_0 => D_PHI_0
     );
 
     U_ADDR_DECODER : MMU_ADDR_DECODER port map(
@@ -550,16 +533,16 @@ begin
     );
 
     U_MMU_ROMEN : MMU_ROMEN port map(
-        DELAYED_PHI_0 => DELAYED_PHI_0,
-        INTC8ACC      => INTC8ACC,
-        INTC3ACC_N    => INTC3ACC_N,
-        CXXX          => CXXX,
-        DXXX_N        => DXXX_N,
-        E_FXXX_N      => E_FXXX_N,
-        INH           => INH,
-        RDROM         => RDROM,
-        CENROM1       => CENROM1,
-        R_W_N         => R_W_N,
+        D_PHI_0     => D_PHI_0,
+        INTC8ACC    => INTC8ACC,
+        INTC3ACC_N  => INTC3ACC_N,
+        CXXX        => CXXX,
+        DXXX_N      => DXXX_N,
+        E_FXXX_N    => E_FXXX_N,
+        INH         => INH,
+        RDROM       => RDROM,
+        CENROM1     => CENROM1,
+        R_W_N       => R_W_N,
 
         ROMEN2_N => ROMEN2_N,
         ROMEN1_N => ROMEN1_N
@@ -587,7 +570,7 @@ begin
     U_MMU_EN80 : MMU_EN80 port map(
         SELMB_N  => SELMB_N,
         INH_N    => INH_N,
-        PHI_0    => DELAYED_PHI_0,
+        PHI_0    => D_PHI_0,
         PCASEN_N => PCASEN_N,
         EN80_N   => EN80_N
     );
@@ -600,17 +583,16 @@ begin
     );
 
     U_MMU_RA : MMU_RA port map(
-        A         => A,
-        RAS_N     => RAS_N,
-        PHI_0     => PHI_0,
-        Q3        => DELAYED_Q3,
-        DXXX_N    => DXXX_N,
-        BANK1     => BANK1,
+        A       => A,
+        PHI_0   => PHI_0,
+        Q3      => Q3,
+        PRAS_N  => PRAS_N,
+        DXXX_N  => DXXX_N,
+        BANK1   => BANK1,
 
-        RA       => UNGATED_RA,
+        RA          => UNGATED_RA,
         RA_ENABLE_N => RA_ENABLE_N
     );
     ORA <= UNGATED_RA when RA_ENABLE_N = '0' else (others => 'Z');
-
 
 end RTL;

--- a/MMU/MMU_RA.vhdl
+++ b/MMU/MMU_RA.vhdl
@@ -3,12 +3,12 @@ use IEEE.std_logic_1164.all;
 
 entity MMU_RA is
     port (
-        A      : in std_logic_vector(15 downto 0);
-        RAS_N  : in std_logic;
-        PHI_0  : in std_logic;
-        Q3     : in std_logic;
-        DXXX_N : in std_logic;
-        BANK1  : in std_logic;
+        A       : in std_logic_vector(15 downto 0);
+        PHI_0   : in std_logic;
+        PRAS_N  : in std_logic;
+        Q3      : in std_logic;
+        DXXX_N  : in std_logic;
+        BANK1   : in std_logic;
 
         RA          : out std_logic_vector(7 downto 0);
         RA_ENABLE_N : out std_logic
@@ -19,7 +19,7 @@ architecture RTL of MMU_RA is
     component RA_MUX is
         port (
             PHI     : in std_logic;
-            RAS_N   : in std_logic;
+            PRAS_N  : in std_logic;
             Q3      : in std_logic;
             ROW_RA0, ROW_RA1, ROW_RA2, ROW_RA3,
             ROW_RA4, ROW_RA5, ROW_RA6, ROW_RA7 : in std_logic;
@@ -37,9 +37,9 @@ begin
     -- MMU_2 @C-4:H4-6
     MA12 <= ((not DXXX_N) and BANK1) xor A(12);
     IOU_RA_MUX : RA_MUX port map(
-        PHI   => PHI_0,
-        RAS_N => RAS_N,
-        Q3    => Q3,
+        PHI    => PHI_0,
+        PRAS_N => PRAS_N,
+        Q3     => Q3,
 
         -- MMU_1 @ @C-4:E5 and D5
         ROW_RA0 => A(0),

--- a/MMU/MMU_ROMEN.vhdl
+++ b/MMU/MMU_ROMEN.vhdl
@@ -3,7 +3,7 @@ use IEEE.std_logic_1164.all;
 
 entity MMU_ROMEN is
     port (
-        DELAYED_PHI_0 : in std_logic;
+        D_PHI_0       : in std_logic;  -- Delayed PHI_0
         INTC8ACC      : in std_logic;
         INTC3ACC_N    : in std_logic;
         CXXX          : in std_logic;
@@ -30,13 +30,13 @@ architecture RTL of MMU_ROMEN is
     signal B5_6, L5_11, K2_12, D2_12 : std_logic;
 begin
     -- MMU_2 @D-4:L5-8
-    B5_6     <= not (RDROM and R_W_N and DELAYED_PHI_0);
+    B5_6     <= not (RDROM and R_W_N and D_PHI_0);
     ROMEN2_N <= B5_6 or E_FXXX_N or INH; -- INH not present in the schematics, but present in the ASIC schematic
 
     -- MMU_2 @D-3:K2-6
     L5_11    <= B5_6 or DXXX_N;
-    K2_12    <= not (CENROM1 and CXXX and DELAYED_PHI_0);
-    D2_12    <= (INTC8ACC or (not INTC3ACC_N)) nand DELAYED_PHI_0;
+    K2_12    <= not (CENROM1 and CXXX and D_PHI_0);
+    D2_12    <= (INTC8ACC or (not INTC3ACC_N)) nand D_PHI_0;
     ROMEN1_N <= (K2_12 and L5_11 and D2_12) or INH; -- INH handwritten in the schematics
 
 end RTL;

--- a/test/COMMON/RA_MUX_TB.vhdl
+++ b/test/COMMON/RA_MUX_TB.vhdl
@@ -9,7 +9,7 @@ architecture RA_MUX_TEST of RA_MUX_TB is
     component RA_MUX is
         port (
             PHI     : in std_logic;
-            RAS_N   : in std_logic;
+            PRAS_N  : in std_logic;
             Q3      : in std_logic;
             ROW_RA0, ROW_RA1, ROW_RA2, ROW_RA3,
             ROW_RA4, ROW_RA5, ROW_RA6, ROW_RA7 : in std_logic;
@@ -22,7 +22,7 @@ architecture RA_MUX_TEST of RA_MUX_TB is
         );
     end component;
 
-    signal PHI, RAS_N, Q3 : std_logic;
+    signal PHI, PRAS_N, Q3 : std_logic;
     signal ROW_RA0, ROW_RA1, ROW_RA2, ROW_RA3,
     ROW_RA4, ROW_RA5, ROW_RA6, ROW_RA7 : std_logic;
     signal COL_RA0, COL_RA1, COL_RA2, COL_RA3,
@@ -34,7 +34,7 @@ architecture RA_MUX_TEST of RA_MUX_TB is
 begin
     dut : RA_MUX port map(
         PHI   => PHI,
-        RAS_N => RAS_N,
+        PRAS_N => PRAS_N,
         Q3    => Q3,
 
         ROW_RA0 => ROW_RA0,
@@ -70,61 +70,55 @@ begin
         -- RA_ENABLE_N TESTS
         PHI <= '0';
         Q3 <= '0';
-        RAS_N <= '0';
-        wait for 1 ns;
-        assert(RA_ENABLE_N = '1') report "Expected RA_ENABLE_N HIGH" severity error;
-
-        PHI <= '0';
-        Q3 <= '0';
-        RAS_N <= '1';
+        PRAS_N <= '1';
         wait for 1 ns;
         assert(RA_ENABLE_N = '0') report "Expected RA_ENABLE_N LOW" severity error;
 
         PHI <= '1';
         Q3 <= '1';
-        RAS_N <= '1';
+        PRAS_N <= '1';
         wait for 1 ns;
         assert(RA_ENABLE_N = '0') report "Expected RA_ENABLE_N LOW" severity error;
 
         PHI <= '1';
         Q3 <= '1';
-        RAS_N <= '0';
+        PRAS_N <= '0';
         wait for 1 ns;
         assert(RA_ENABLE_N = '0') report "Expected RA_ENABLE_N LOW" severity error;
 
         PHI <= '1';
         Q3 <= '0';
-        RAS_N <= '0';
+        PRAS_N <= '0';
         wait for 1 ns;
         assert(RA_ENABLE_N = '1') report "Expected RA_ENABLE_N HIGH" severity error;
 
         PHI <= '1';
         Q3 <= '0';
-        RAS_N <= '1';
+        PRAS_N <= '1';
         wait for 1 ns;
         assert(RA_ENABLE_N = '1') report "Expected RA_ENABLE_N HIGH" severity error;
 
         PHI <= '1';
         Q3 <= '0';
-        RAS_N <= '1';
+        PRAS_N <= '1';
         wait for 1 ns;
         assert(RA_ENABLE_N = '1') report "Expected RA_ENABLE_N HIGH" severity error;
 
         PHI <= '0';
         Q3 <= '1';
-        RAS_N <= '1';
+        PRAS_N <= '1';
         wait for 1 ns;
         assert(RA_ENABLE_N = '1') report "Expected RA_ENABLE_N HIGH" severity error;
 
         PHI <= '0';
         Q3 <= '1';
-        RAS_N <= '0';
+        PRAS_N <= '0';
         wait for 1 ns;
         assert(RA_ENABLE_N = '1') report "Expected RA_ENABLE_N HIGH" severity error;
 
         PHI <= '0';
         Q3 <= '0';
-        RAS_N <= '0';
+        PRAS_N <= '0';
         wait for 1 ns;
         assert(RA_ENABLE_N = '1') report "Expected RA_ENABLE_N HIGH" severity error;
 
@@ -146,16 +140,16 @@ begin
         COL_RA6 <= 'U';
         COL_RA7 <= 'U';
 
-        RAS_N <= '1';
+        PRAS_N <= '1';
         wait for 1 ns;
-        assert(RA0 = '0') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
-        assert(RA1 = '1') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
-        assert(RA2 = '0') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
-        assert(RA3 = '1') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
-        assert(RA4 = '0') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
-        assert(RA5 = '1') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
-        assert(RA6 = '0') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
-        assert(RA7 = '1') report "When PRAS_N is LOW and RAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA0 = '0') report "When PRAS_N is LOW and PRAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA1 = '1') report "When PRAS_N is LOW and PRAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA2 = '0') report "When PRAS_N is LOW and PRAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA3 = '1') report "When PRAS_N is LOW and PRAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA4 = '0') report "When PRAS_N is LOW and PRAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA5 = '1') report "When PRAS_N is LOW and PRAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA6 = '0') report "When PRAS_N is LOW and PRAS_N is HIGH, RA should be ROW addresses" severity error;
+        assert(RA7 = '1') report "When PRAS_N is LOW and PRAS_N is HIGH, RA should be ROW addresses" severity error;
 
         ROW_RA0 <= 'U';
         ROW_RA1 <= 'U';
@@ -174,16 +168,16 @@ begin
         COL_RA6 <= '0';
         COL_RA7 <= '1';
 
-        RAS_N <= '0';
+        PRAS_N <= '0';
         wait for 1 ns;
-        assert(RA0 = '0') report "When RAS_N is LOW, RA should be COL addresses" severity error;
-        assert(RA1 = '1') report "When RAS_N is LOW, RA should be COL addresses" severity error;
-        assert(RA2 = '0') report "When RAS_N is LOW, RA should be COL addresses" severity error;
-        assert(RA3 = '1') report "When RAS_N is LOW, RA should be COL addresses" severity error;
-        assert(RA4 = '0') report "When RAS_N is LOW, RA should be COL addresses" severity error;
-        assert(RA5 = '1') report "When RAS_N is LOW, RA should be COL addresses" severity error;
-        assert(RA6 = '0') report "When RAS_N is LOW, RA should be COL addresses" severity error;
-        assert(RA7 = '1') report "When RAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA0 = '0') report "When PRAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA1 = '1') report "When PRAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA2 = '0') report "When PRAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA3 = '1') report "When PRAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA4 = '0') report "When PRAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA5 = '1') report "When PRAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA6 = '0') report "When PRAS_N is LOW, RA should be COL addresses" severity error;
+        assert(RA7 = '1') report "When PRAS_N is LOW, RA should be COL addresses" severity error;
 
         assert false report "Test done." severity note;
         wait;

--- a/test/IOU/VIDEO_ADDR_MUX_TB.vhdl
+++ b/test/IOU/VIDEO_ADDR_MUX_TB.vhdl
@@ -9,12 +9,12 @@ architecture VIDEO_ADDR_MUX_TEST of VIDEO_ADDR_MUX_TB is
     component VIDEO_ADDR_MUX is
         port (
             PHI_1          : in std_logic;
+            PRAS_N         : in std_logic;
             Q3             : in std_logic;
             PG2_N          : in std_logic;
             EN80VID        : in std_logic;
             HIRESEN_N      : in std_logic;
             VA, VB, VC     : in std_logic;
-            RAS_N          : in std_logic;
             V0, V1, V2     : in std_logic;
             H0, H1, H2     : in std_logic;
             E0, E1, E2, E3 : in std_logic;
@@ -31,7 +31,7 @@ architecture VIDEO_ADDR_MUX_TEST of VIDEO_ADDR_MUX_TB is
     signal EN80VID        : std_logic;
     signal HIRESEN_N      : std_logic;
     signal VA, VB, VC     : std_logic;
-    signal RAS_N          : std_logic;
+    signal PRAS_N         : std_logic;
     signal V0, V1, V2     : std_logic;
     signal H0, H1, H2     : std_logic;
     signal E0, E1, E2, E3 : std_logic;
@@ -50,7 +50,7 @@ begin
         VA          => VA,
         VB          => VB,
         VC          => VC,
-        RAS_N       => RAS_N,
+        PRAS_N      => PRAS_N,
         V0          => V0,
         V1          => V1,
         V2          => V2,
@@ -74,7 +74,7 @@ begin
 
     process begin
         -- ZA-ZE tests
-        RAS_N <= '0';
+        PRAS_N <= '0';
 
         PG2_N     <= '0';
         EN80VID   <= '0';
@@ -135,7 +135,7 @@ begin
         assert(RA6 = '0') report "expect ZE LOW" severity error;
 
         -- RA0-RA7 tests
-        RAS_N    <= '0';
+        PRAS_N    <= '0';
         V1        <= '1';
         V2        <= '1';
         E3        <= '1';
@@ -155,7 +155,7 @@ begin
         assert(RA6 = '1') report "expect RA6 HIGH" severity error;
         assert(RA7 = '0') report "expect RA7 LOW" severity error;
 
-        RAS_N    <= '1';
+        PRAS_N    <= '1';
         VA        <= 'U';
         VB        <= 'U';
         VC        <= 'U';

--- a/test/IOU/test_cases/mocks/CPU_MMU_MOCK.vhdl
+++ b/test/IOU/test_cases/mocks/CPU_MMU_MOCK.vhdl
@@ -30,9 +30,9 @@ architecture MOCK of CPU_MMU_MOCK is
     component MMU_RA is
         port (
             A      : in std_logic_vector(15 downto 0);
-            RAS_N  : in std_logic;
             PHI_0  : in std_logic;
             Q3     : in std_logic;
+            PRAS_N  : in std_logic;
             DXXX_N : in std_logic;
             BANK1  : in std_logic;
 
@@ -72,8 +72,8 @@ begin
 
     U_MMU_RA : MMU_RA port map(
         A           => "0000000000000000",
-        RAS_N       => PRAS_N,
-        PHI_0     => PHI_0,
+        PRAS_N      => PRAS_N,
+        PHI_0       => PHI_0,
         Q3          => Q3,
         DXXX_N      => '0',
         BANK1       => '0',

--- a/test/IOU/test_cases/mocks/VIDEO_ADDR_MUX_SPY.vhdl
+++ b/test/IOU/test_cases/mocks/VIDEO_ADDR_MUX_SPY.vhdl
@@ -5,12 +5,12 @@ use work.IOU_TESTBENCH_PACKAGE.all;
 entity VIDEO_ADDR_MUX_SPY is
     port (
         PHI_1          : in std_logic;
+        PRAS_N          : in std_logic;
         Q3             : in std_logic;
         PG2_N          : in std_logic;
         EN80VID        : in std_logic;
         HIRESEN_N      : in std_logic;
         VA, VB, VC     : in std_logic;
-        RAS_N          : in std_logic;
         V0, V1, V2     : in std_logic;
         H0, H1, H2     : in std_logic;
         E0, E1, E2, E3 : in std_logic;
@@ -30,7 +30,7 @@ architecture SPY of VIDEO_ADDR_MUX_SPY is
             EN80VID        : in std_logic;
             HIRESEN_N      : in std_logic;
             VA, VB, VC     : in std_logic;
-            RAS_N          : in std_logic;
+            PRAS_N         : in std_logic;
             V0, V1, V2     : in std_logic;
             H0, H1, H2     : in std_logic;
             E0, E1, E2, E3 : in std_logic;
@@ -53,7 +53,7 @@ begin
         VA          => VA,
         VB          => VB,
         VC          => VC,
-        RAS_N       => RAS_N,
+        PRAS_N      => PRAS_N,
         V0          => V0,
         V1          => V1,
         V2          => V2,

--- a/test/MMU/MMU_RA_TB.vhdl
+++ b/test/MMU/MMU_RA_TB.vhdl
@@ -7,12 +7,12 @@ end MMU_RA_TB;
 architecture MMU_RA_TEST of MMU_RA_TB is
     component MMU_RA is
         port (
-            A      : in std_logic_vector(15 downto 0);
-            RAS_N  : in std_logic;
-            PHI_0  : in std_logic;
-            Q3     : in std_logic;
-            DXXX_N : in std_logic;
-            BANK1  : in std_logic;
+            A       : in std_logic_vector(15 downto 0);
+            PHI_0   : in std_logic;
+            PRAS_N  : in std_logic;
+            Q3      : in std_logic;
+            DXXX_N  : in std_logic;
+            BANK1   : in std_logic;
 
             RA          : out std_logic_vector(7 downto 0);
             RA_ENABLE_N : out std_logic
@@ -20,7 +20,7 @@ architecture MMU_RA_TEST of MMU_RA_TB is
     end component;
 
     signal A         : std_logic_vector(15 downto 0);
-    signal RAS_N    : std_logic;
+    signal PRAS_N    : std_logic;
     signal PHI_0     : std_logic;
     signal Q3        : std_logic;
     signal DXXX_N    : std_logic;
@@ -31,7 +31,7 @@ architecture MMU_RA_TEST of MMU_RA_TB is
 begin
     dut : MMU_RA port map(
         A         => A,
-        RAS_N     => RAS_N,
+        PRAS_N    => PRAS_N,
         PHI_0     => PHI_0,
         Q3        => Q3,
         DXXX_N    => DXXX_N,
@@ -42,12 +42,12 @@ begin
 
     process begin
         A     <= "XXXXXXX00X000000";
-        RAS_N <= '1';
+        PRAS_N <= '1';
         wait for 1 ns;
         assert(RA = "00000000") report "When PRAS_N HIGH; expect B branch of the LS257 to be selected" severity error;
 
         A      <= "010X000XX1XXXXXX";
-        RAS_N  <= '0';
+        PRAS_N  <= '0';
         DXXX_N <= '0';
         BANK1  <= '0';
         A(12)  <= '0';
@@ -55,7 +55,7 @@ begin
         assert(RA = "01000010") report "When PRAS_N LOW; expect A branch of the LS257 to be selected" severity error;
 
         A      <= "XXXXXXXXXXXXXXXX";
-        RAS_N  <= '0';
+        PRAS_N  <= '0';
         DXXX_N <= '1';
         BANK1  <= '0';
         A(12)  <= '0';
@@ -63,7 +63,7 @@ begin
         assert(RA(4) = '0') report "When DXXX_N HIGH, BANK1 and A(12) LOW; expect MA12 LOW" severity error;
 
         A      <= "XXXXXXXXXXXXXXXX";
-        RAS_N  <= '0';
+        PRAS_N  <= '0';
         DXXX_N <= '0';
         BANK1  <= '1';
         A(12)  <= '0';
@@ -71,7 +71,7 @@ begin
         assert(RA(4) = '1') report "When DXXX_N LOW, BANK1 HIGH, and A(12) LOW; expect MA12 HIGH" severity error;
 
         A      <= "XXXXXXXXXXXXXXXX";
-        RAS_N  <= '0';
+        PRAS_N  <= '0';
         DXXX_N <= '0';
         BANK1  <= '0';
         A(12)  <= '1';
@@ -81,7 +81,7 @@ begin
         A      <= x"D123";
         BANK1  <= '0';
         DXXX_N <= '0';
-        RAS_N  <= '1';
+        PRAS_N  <= '1';
         wait for 1 ns;
         assert(RA(0) = A(0)) report "expect RA(0) equals A(0)" severity error;
         assert(RA(1) = A(1)) report "expect RA(1) equals A(1)" severity error;
@@ -95,7 +95,7 @@ begin
         A      <= x"D123";
         BANK1  <= '0';
         DXXX_N <= '0';
-        RAS_N  <= '0';
+        PRAS_N  <= '0';
         wait for 1 ns;
         assert(RA(0) = A(9)) report "expect RA(0) equals A(9)" severity error;
         assert(RA(1) = A(6)) report "expect RA(1) equals A(6)" severity error;

--- a/test/MMU/MMU_ROMEN_TB.vhdl
+++ b/test/MMU/MMU_ROMEN_TB.vhdl
@@ -7,23 +7,23 @@ end MMU_ROMEN_TB;
 architecture MMU_ROMEN_TEST of MMU_ROMEN_TB is
     component MMU_ROMEN is
         port (
-            DELAYED_PHI_0 : in std_logic;
-            INTC8ACC      : in std_logic;
-            INTC3ACC_N    : in std_logic;
-            CXXX          : in std_logic;
-            DXXX_N        : in std_logic;
-            E_FXXX_N      : in std_logic;
-            INH           : in std_logic;
-            RDROM         : in std_logic;
-            CENROM1       : in std_logic;
-            R_W_N         : in std_logic;
+            D_PHI_0    : in std_logic;
+            INTC8ACC   : in std_logic;
+            INTC3ACC_N : in std_logic;
+            CXXX       : in std_logic;
+            DXXX_N     : in std_logic;
+            E_FXXX_N   : in std_logic;
+            INH        : in std_logic;
+            RDROM      : in std_logic;
+            CENROM1    : in std_logic;
+            R_W_N      : in std_logic;
 
             ROMEN2_N : out std_logic;
             ROMEN1_N : out std_logic
         );
     end component;
 
-    signal DELAYED_PHI_0      : std_logic;
+    signal D_PHI_0    : std_logic;
     signal INTC8ACC   : std_logic;
     signal INTC3ACC_N : std_logic;
     signal CXXX       : std_logic;
@@ -38,18 +38,18 @@ architecture MMU_ROMEN_TEST of MMU_ROMEN_TB is
 
 begin
     dut : MMU_ROMEN port map(
-        DELAYED_PHI_0 => DELAYED_PHI_0,
-        INTC8ACC      => INTC8ACC,
-        INTC3ACC_N    => INTC3ACC_N,
-        CXXX          => CXXX,
-        DXXX_N        => DXXX_N,
-        E_FXXX_N      => E_FXXX_N,
-        INH           => INH,
-        RDROM         => RDROM,
-        CENROM1       => CENROM1,
-        R_W_N         => R_W_N,
-        ROMEN2_N      => ROMEN2_N,
-        ROMEN1_N      => ROMEN1_N
+        D_PHI_0    => D_PHI_0,
+        INTC8ACC   => INTC8ACC,
+        INTC3ACC_N => INTC3ACC_N,
+        CXXX       => CXXX,
+        DXXX_N     => DXXX_N,
+        E_FXXX_N   => E_FXXX_N,
+        INH        => INH,
+        RDROM      => RDROM,
+        CENROM1    => CENROM1,
+        R_W_N      => R_W_N,
+        ROMEN2_N   => ROMEN2_N,
+        ROMEN1_N   => ROMEN1_N
     );
 
     process begin
@@ -57,35 +57,35 @@ begin
         INH      <= '0';
         RDROM    <= '0';
         R_W_N    <= '0';
-        DELAYED_PHI_0 <= '0';
+        D_PHI_0 <= '0';
         E_FXXX_N <= '0';
         wait for 1 ns;
         assert(ROMEN2_N = '1') report "expect ROMEN2 HIGH" severity error;
 
         RDROM    <= '1';
         R_W_N    <= '1';
-        DELAYED_PHI_0 <= '1';
+        D_PHI_0 <= '1';
         E_FXXX_N <= '0';
         wait for 1 ns;
         assert(ROMEN2_N = '0') report "expect ROMEN2 LOW" severity error;
 
         RDROM    <= '0';
         R_W_N    <= '1';
-        DELAYED_PHI_0 <= '1';
+        D_PHI_0 <= '1';
         E_FXXX_N <= '0';
         wait for 1 ns;
         assert(ROMEN2_N = '1') report "expect ROMEN2 HIGH" severity error;
 
         RDROM    <= '0';
         R_W_N    <= '1';
-        DELAYED_PHI_0 <= '1';
+        D_PHI_0 <= '1';
         E_FXXX_N <= '1';
         wait for 1 ns;
         assert(ROMEN2_N = '1') report "expect ROMEN2 HIGH" severity error;
 
         RDROM    <= '0';
         R_W_N    <= '1';
-        DELAYED_PHI_0 <= '1';
+        D_PHI_0 <= '1';
         E_FXXX_N <= '1';
         wait for 1 ns;
         assert(ROMEN2_N = '1') report "expect ROMEN2 HIGH" severity error;
@@ -93,7 +93,7 @@ begin
         INH      <= '1';
         RDROM    <= '1';
         R_W_N    <= '1';
-        DELAYED_PHI_0 <= '1';
+        D_PHI_0 <= '1';
         E_FXXX_N <= '0';
         wait for 1 ns;
         assert(ROMEN2_N = '1') report "expect ROMEN2 HIGH" severity error;
@@ -102,7 +102,7 @@ begin
         INH        <= '0';
         CENROM1    <= '0';
         CXXX       <= '1';
-        DELAYED_PHI_0 <= '1';
+        D_PHI_0 <= '1';
         RDROM      <= '0';
         R_W_N      <= '0';
         DXXX_N     <= '1';
@@ -114,7 +114,7 @@ begin
         INH        <= '0';
         CENROM1    <= '1';
         CXXX       <= '1';
-        DELAYED_PHI_0 <= '1';
+        D_PHI_0 <= '1';
         RDROM      <= '0';
         R_W_N      <= '0';
         DXXX_N     <= '1';
@@ -126,7 +126,7 @@ begin
         INH        <= '0';
         CENROM1    <= '0';
         CXXX       <= '1';
-        DELAYED_PHI_0 <= '1';
+        D_PHI_0 <= '1';
         RDROM      <= '0';
         R_W_N      <= '0';
         DXXX_N     <= '1';


### PR DESCRIPTION
Fixed the glitch with RA_ENABLE_N (COMMON/RA_MUX.vhdl) (see https://github.com/frozen-signal/Apple_IIe_MMU_IOU/issues/47)
Renamed the 'delayed' signals so that they all start with 'D_'.